### PR TITLE
Mailing.preview API - Override core's version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Change Log
+
+## v0.2-alpha1
+
+ * Override core's `Mailing.preview` API to support rendering via
+   Flexmailer events.
+ * (BC Break) In the class `DefaultComposer`, change the signature for
+   `createMessageTemplates()` and `applyClickTracking()` to provide full
+   access to the event context (`$e`).

--- a/README.md
+++ b/README.md
@@ -14,8 +14,16 @@ change behaviors in more fine-grained ways.
 
 ## Installation
 
+To download the latest alpha or beta version:
+
 ```
 cv dl --dev flexmailer
+```
+
+To download the latest code from git:
+
+```
+git clone https://github.com/civicrm/org.civicrm.flexmailer.git $(cv path -x ./org.civicrm.flexmailer)
 ```
 
 ## Unit Tests

--- a/flexmailer.php
+++ b/flexmailer.php
@@ -51,8 +51,6 @@ function flexmailer_civicrm_config(&$config) {
 /**
  * Implements hook_civicrm_xmlMenu().
  *
- * @param array $files
- *
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_xmlMenu
  */
 function flexmailer_civicrm_xmlMenu(&$files) {
@@ -69,10 +67,10 @@ function flexmailer_civicrm_install() {
 }
 
 /**
-* Implements hook_civicrm_postInstall().
-*
-* @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_postInstall
-*/
+ * Implements hook_civicrm_postInstall().
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_postInstall
+ */
 function flexmailer_civicrm_postInstall() {
   _flexmailer_civix_civicrm_postInstall();
 }
@@ -107,13 +105,6 @@ function flexmailer_civicrm_disable() {
 /**
  * Implements hook_civicrm_upgrade().
  *
- * @param $op string, the type of operation being performed; 'check' or 'enqueue'
- * @param $queue CRM_Queue_Queue, (for 'enqueue') the modifiable list of pending up upgrade tasks
- *
- * @return mixed
- *   Based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
- *                for 'enqueue', returns void
- *
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_upgrade
  */
 function flexmailer_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
@@ -137,8 +128,6 @@ function flexmailer_civicrm_managed(&$entities) {
  *
  * Generate a list of case-types.
  *
- * @param array $caseTypes
- *
  * Note: This hook only runs in CiviCRM 4.4+.
  *
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_caseTypes
@@ -158,7 +147,7 @@ function flexmailer_civicrm_caseTypes(&$caseTypes) {
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_caseTypes
  */
 function flexmailer_civicrm_angularModules(&$angularModules) {
-_flexmailer_civix_civicrm_angularModules($angularModules);
+  _flexmailer_civix_civicrm_angularModules($angularModules);
 }
 
 /**
@@ -173,7 +162,6 @@ function flexmailer_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
 /**
  * Functions below this ship commented out. Uncomment as required.
  *
-
 /**
  * Implements hook_civicrm_preProcess().
  *

--- a/flexmailer.php
+++ b/flexmailer.php
@@ -46,6 +46,10 @@ spl_autoload_register('_flexmailer_autoload');
  */
 function flexmailer_civicrm_config(&$config) {
   _flexmailer_civix_civicrm_config($config);
+
+  /** @var \Civi\API\Kernel $kernel */
+  $kernel = Civi::service('civi_api_kernel');
+  $kernel->registerApiProvider(Civi::service('civi_flexmailer_api_overrides'));
 }
 
 /**

--- a/info.xml
+++ b/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2016-12-29</releaseDate>
-  <version>0.1-alpha2</version>
+  <version>0.2-alpha1</version>
   <compatibility>
     <ver>4.7</ver>
   </compatibility>

--- a/src/API/MailingPreview.php
+++ b/src/API/MailingPreview.php
@@ -40,6 +40,7 @@ class MailingPreview {
     $job->save();
 
     $flexMailer = new FlexMailer(array(
+      'is_preview' => TRUE,
       'mailing' => $mailing,
       'job' => $job, // HMM?
       'attachments' => \CRM_Core_BAO_File::getEntityFile('civicrm_mailing',

--- a/src/API/MailingPreview.php
+++ b/src/API/MailingPreview.php
@@ -56,8 +56,6 @@ class MailingPreview {
 
     $flexMailer->fireComposeBatch(array($task));
 
-    $job->delete();
-
     return civicrm_api3_create_success(array(
       'id' => $params['id'],
       'contact_id' => $contactID,

--- a/src/API/MailingPreview.php
+++ b/src/API/MailingPreview.php
@@ -1,0 +1,70 @@
+<?php
+namespace Civi\FlexMailer\API;
+
+use Civi\FlexMailer\FlexMailer;
+use Civi\FlexMailer\FlexMailerTask;
+use Civi\FlexMailer\Listener\Abdicator;
+
+class MailingPreview {
+
+  /**
+   * Generate a preview of how a mailing would look.
+   *
+   * @param array $apiRequest
+   *  - entity: string
+   *  - action: string
+   *  - params: array
+   *     - id: int
+   *     - contact_id: int
+   * @return array
+   * @throws \CRM_Core_Exception
+   */
+  public static function preview($apiRequest) {
+    $params = $apiRequest['params'];
+
+    /** @var \CRM_Mailing_BAO_Mailing $mailing */
+    $mailing = \CRM_Mailing_BAO_Mailing::findById($params['id']);
+
+    if (!Abdicator::isFlexmailPreferred($mailing)) {
+      require_once 'api/v3/Mailing.php';
+      return civicrm_api3_mailing_preview($params);
+    }
+
+    $contactID = \CRM_Utils_Array::value('contact_id', $params,
+      \CRM_Core_Session::singleton()->get('userID'));
+
+    $job = new \CRM_Mailing_BAO_MailingJob();
+    $job->mailing_id = $mailing->id;
+    $job->is_test = 1;
+    $job->status = 'Complete';
+    $job->save();
+
+    $flexMailer = new FlexMailer(array(
+      'mailing' => $mailing,
+      'job' => $job, // HMM?
+      'attachments' => \CRM_Core_BAO_File::getEntityFile('civicrm_mailing',
+        $mailing->id),
+    ));
+
+    if (count($flexMailer->validate()) > 0) {
+      throw new \CRM_Core_Exception("FlexMailer cannot execute: invalid context");
+    }
+
+    $task = new FlexMailerTask($job->id, $contactID, 'fakehash',
+      'placeholder@example.com');
+
+    $flexMailer->fireComposeBatch(array($task));
+
+    $job->delete();
+
+    return civicrm_api3_create_success(array(
+      'id' => $params['id'],
+      'contact_id' => $contactID,
+      'subject' => $task->getMailParam('Subject'),
+      'body_html' => $task->getMailParam('html'),
+      'body_text' => $task->getMailParam('text'),
+      '_rendered_by_' => 'flexmailer', // To support tests
+    ));
+  }
+
+}

--- a/src/Event/ComposeBatchEvent.php
+++ b/src/Event/ComposeBatchEvent.php
@@ -59,4 +59,13 @@ class ComposeBatchEvent extends BaseEvent {
     return $this->tasks;
   }
 
+  /**
+   * @return bool
+   */
+  public function isPreview() {
+    return isset($this->context['is_preview'])
+      ? (bool) $this->context['is_preview']
+      : FALSE;
+  }
+
 }

--- a/src/FlexMailer.php
+++ b/src/FlexMailer.php
@@ -117,6 +117,7 @@ class FlexMailer {
    *     - mailing: \CRM_Mailing_BAO_Mailing
    *     - job: \CRM_Mailing_BAO_MailingJob
    *     - attachments: array
+   *     - is_preview: bool
    *
    * Additional options may be passed. To avoid naming conflicts, use prefixing.
    */

--- a/src/Listener/BasicHeaders.php
+++ b/src/Listener/BasicHeaders.php
@@ -69,7 +69,7 @@ class BasicHeaders extends BaseListener {
       //  $mailParams['Reply-To'] = $mailing->replyto_email;
       // }
 
-      if (!\CRM_Mailing_BAO_Mailing::overrideVerp($e->getJob()->id)) {
+      if (!$mailing->override_verp) {
         $mailParams['Reply-To'] = $verp['reply'];
       }
       elseif ($mailing->replyto_email && ($mailParams['From'] != $mailing->replyto_email)) {

--- a/src/Listener/DefaultComposer.php
+++ b/src/Listener/DefaultComposer.php
@@ -221,8 +221,10 @@ class DefaultComposer extends BaseListener {
    * @param \Civi\FlexMailer\Event\ComposeBatchEvent $e
    * @return bool
    */
-  protected function isClickTracking(ComposeBatchEvent $e) {
-    return $e->getMailing()->url_tracking;
+  public function isClickTracking(ComposeBatchEvent $e) {
+    // Don't track clicks on previews. Doing so would accumulate a lot
+    // of garbage data.
+    return $e->getMailing()->url_tracking && !$e->isPreview();
   }
 
 }

--- a/tests/phpunit/Civi/FlexMailer/MailingPreviewTest.php
+++ b/tests/phpunit/Civi/FlexMailer/MailingPreviewTest.php
@@ -1,0 +1,100 @@
+<?php
+namespace Civi\FlexMailer;
+
+class MailingPreviewTest extends \CiviUnitTestCase {
+
+  protected $_groupID;
+  protected $_email;
+  protected $_apiversion = 3;
+  protected $_params = array();
+  protected $_entity = 'Mailing';
+  protected $_contactID;
+
+  /**
+   * APIv3 result from creating an example footer
+   * @var array
+   */
+  protected $footer;
+
+  public function setUp() {
+    // Activate before transactions are setup.
+    $manager = \CRM_Extension_System::singleton()->getManager();
+    if ($manager->getStatus('org.civicrm.flexmailer') !== \CRM_Extension_Manager::STATUS_INSTALLED) {
+      $manager->install(array('org.civicrm.flexmailer'));
+    }
+
+    parent::setUp();
+
+    \CRM_Core_BAO_Setting::setItem(TRUE, 'Mailing Preferences', 'experimentalFlexMailerEngine');
+
+    $this->useTransaction();
+    \CRM_Mailing_BAO_MailingJob::$mailsProcessed = 0; // DGW
+    $this->_contactID = $this->individualCreate();
+    $this->_groupID = $this->groupCreate();
+    $this->_email = 'test@test.test';
+    $this->_params = array(
+      'subject' => 'Hello {contact.display_name}',
+      'body_text' => "This is {contact.display_name}.\nhttps://civicrm.org\n{domain.address}{action.optOutUrl}",
+      'body_html' => "<p>This is {contact.display_name}.</p><p><a href='https://civicrm.org/'>CiviCRM.org</a></p><p>{domain.address}{action.optOutUrl}</p>",
+      'name' => 'mailing name',
+      'created_id' => $this->_contactID,
+      'header_id' => '',
+      'footer_id' => '',
+    );
+
+    $this->footer = civicrm_api3('MailingComponent', 'create', array(
+      'name' => 'test domain footer',
+      'component_type' => 'footer',
+      'body_html' => '<p>From {domain.address}. To opt out, go to {action.optOutUrl}.</p>',
+      'body_text' => 'From {domain.address}. To opt out, go to {action.optOutUrl}.',
+    ));
+  }
+
+  public function tearDown() {
+    \CRM_Mailing_BAO_MailingJob::$mailsProcessed = 0; // DGW
+    parent::tearDown();
+  }
+
+  public function testMailerPreview() {
+    // BEGIN SAMPLE DATA
+    $contactID = $this->individualCreate();
+    $displayName = $this->callAPISuccess('contact', 'get',
+      array('id' => $contactID));
+    $displayName = $displayName['values'][$contactID]['display_name'];
+    $this->assertTrue(!empty($displayName));
+
+    $params = $this->_params;
+    $params['api.Mailing.preview'] = array(
+      'id' => '$value.id',
+      'contact_id' => $contactID,
+    );
+    $params['options']['force_rollback'] = 1;
+    // END SAMPLE DATA
+
+    $maxIDs = array(
+      'mailing' => \CRM_Core_DAO::singleValueQuery('SELECT MAX(id) FROM civicrm_mailing'),
+      'job' => \CRM_Core_DAO::singleValueQuery('SELECT MAX(id) FROM civicrm_mailing_job'),
+      'group' => \CRM_Core_DAO::singleValueQuery('SELECT MAX(id) FROM civicrm_mailing_group'),
+      'recipient' => \CRM_Core_DAO::singleValueQuery('SELECT MAX(id) FROM civicrm_mailing_recipients'),
+    );
+    $result = $this->callAPISuccess('mailing', 'create', $params);
+    $this->assertDBQuery($maxIDs['mailing'],
+      'SELECT MAX(id) FROM civicrm_mailing'); // 'Preview should not create any mailing records'
+    $this->assertDBQuery($maxIDs['job'],
+      'SELECT MAX(id) FROM civicrm_mailing_job'); // 'Preview should not create any mailing_job record'
+    $this->assertDBQuery($maxIDs['group'],
+      'SELECT MAX(id) FROM civicrm_mailing_group'); // 'Preview should not create any mailing_group records'
+    $this->assertDBQuery($maxIDs['recipient'],
+      'SELECT MAX(id) FROM civicrm_mailing_recipients'); // 'Preview should not create any mailing_recipient records'
+
+    $previewResult = $result['values'][$result['id']]['api.Mailing.preview'];
+    $this->assertEquals("Hello $displayName",
+      $previewResult['values']['subject']);
+    $this->assertContains("This is $displayName",
+      $previewResult['values']['body_text']);
+    $this->assertContains("<p>This is $displayName.</p>",
+      $previewResult['values']['body_html']);
+    $this->assertEquals('flexmailer', $previewResult['values']['_rendered_by_']);
+  }
+
+}


### PR DESCRIPTION
This allows us to apply the same COMPOSE_EVENT listeners to preview
messages that we would apply to real messages.

Additional commits include cleanup/refacotring in support of this change.