### PR TITLE
Fix installation error regarding 'civi_flexmailer_api_overrides'

### DIFF
--- a/flexmailer.php
+++ b/flexmailer.php
@@ -46,10 +46,6 @@ spl_autoload_register('_flexmailer_autoload');
  */
 function flexmailer_civicrm_config(&$config) {
   _flexmailer_civix_civicrm_config($config);
-
-  /** @var \Civi\API\Kernel $kernel */
-  $kernel = Civi::service('civi_api_kernel');
-  $kernel->registerApiProvider(Civi::service('civi_flexmailer_api_overrides'));
 }
 
 /**

--- a/src/Services.php
+++ b/src/Services.php
@@ -28,6 +28,7 @@ namespace Civi\FlexMailer;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher;
 use Civi\FlexMailer\FlexMailer as FM;
 
@@ -64,6 +65,8 @@ class Services {
     foreach (self::getListenerSpecs() as $listenerSpec) {
       $container->findDefinition('dispatcher')->addMethodCall('addListenerService', $listenerSpec);
     }
+
+    $container->findDefinition('civi_api_kernel')->addMethodCall('registerApiProvider', array(new Reference('civi_flexmailer_api_overrides')));
   }
 
   public static function registerListeners(ContainerAwareEventDispatcher $dispatcher) {


### PR DESCRIPTION
The previous code worked in v4.7 because the revised bootstrap ensures that the container is available *before* `hook_civicrm_config` fires. However, the ordering is more nebulous in v4.6.

This change manages to register the API override without using `hook_civicrm_config`.