### PR TITLE
Using i18n getLocale instead of dbLocale variable

### DIFF
--- a/src/FlexMailer.php
+++ b/src/FlexMailer.php
@@ -230,7 +230,7 @@ class FlexMailer {
     // This isn't a great place for this, but it ensures consistent cleanup.
     $mailing = $this->context['mailing'];
     if (property_exists($mailing, 'language') && $mailing->language && $mailing->language != 'en_US') {
-      $swapLang = \CRM_Utils_AutoClean::swap('global://dbLocale?getter', 'call://i18n/setLocale', $mailing->language);
+      $swapLang = \CRM_Utils_AutoClean::swap('call://i18n/getLocale', 'call://i18n/setLocale', $mailing->language);
     }
 
     $event = new ComposeBatchEvent($this->context, $tasks);


### PR DESCRIPTION
cf. https://github.com/civicrm/org.civicrm.flexmailer/issues/4
I have tried tsLocale / getLocale and both seemed to work so i guess getLocale is a better choice.