### PR TITLE
Convert from `civi.flexmailer.*` to `hook_civicrm_*` (#1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,12 @@
 * (BC Break) In the class `DefaultComposer`, change the signature for
   `createMessageTemplates()` and `applyClickTracking()` to provide full
   access to the event context (`$e`).
+
+## v0.3-alpha1
+
+* (BC Break) Convert from internal event notation to external event (hook) notation.
+    * The literal event name has changed from `civi.flexmailer.*` to `hook_civicrm_flexmailer_*`.
+    * Listeners which subscribed using a constant (eg `FlexMailer::EVENT_COMPOSE`) should continue to work as before.
+      However, listeners which used the string literal (eg `civi.flexmailer.compose`) are likely to break.
+    * All event classes now extend `GenericHookEvent`. The main functions should continue to work as before.
+      However, `GenericHookEvent` implements the magic methods (`__get()`, etal); if a customization used undeclared/unofficial properties, they could be impacted.

--- a/docs/develop/index.md
+++ b/docs/develop/index.md
@@ -23,14 +23,15 @@ the system by adding or overriding listeners.
 
     ```
     $ cv debug:event-dispatcher /flexmail/
-    [Event] civi.flexmailer.walk
+    [Event] hook_civicrm_flexmailer_walk
     +-------+---------------------------------------------------+
     | Order | Callable                                          |
     +-------+---------------------------------------------------+
-    | #1    | Civi\FlexMailer\Listener\DefaultBatcher->onWalk() |
+    | #1    | \Civi\Core\CiviEventDispatcher::delegateToUF()    |
+    | #2    | Civi\FlexMailer\Listener\DefaultBatcher->onWalk() |
     +-------+---------------------------------------------------+
 
-    [Event] civi.flexmailer.compose
+    [Event] hook_civicrm_flexmailer_compose
     +-------+-------------------------------------------------------+
     | Order | Callable                                              |
     +-------+-------------------------------------------------------+
@@ -38,19 +39,35 @@ the system by adding or overriding listeners.
     | #2    | Civi\FlexMailer\Listener\ToHeader->onCompose()        |
     | #3    | Civi\FlexMailer\Listener\BounceTracker->onCompose()   |
     | #4    | Civi\FlexMailer\Listener\DefaultComposer->onCompose() |
-    | #5    | Civi\FlexMailer\Listener\Attachments->onCompose()     |
-    | #6    | Civi\FlexMailer\Listener\OpenTracker->onCompose()     |
-    | #7    | Civi\FlexMailer\Listener\HookAdapter->onCompose()     |
+    | #5    | \Civi\Core\CiviEventDispatcher::delegateToUF()        |
+    | #6    | Civi\FlexMailer\Listener\Attachments->onCompose()     |
+    | #7    | Civi\FlexMailer\Listener\OpenTracker->onCompose()     |
+    | #8    | Civi\FlexMailer\Listener\HookAdapter->onCompose()     |
     +-------+-------------------------------------------------------+
 
-    [Event] civi.flexmailer.send
+    [Event] hook_civicrm_flexmailer_send
     +-------+--------------------------------------------------+
     | Order | Callable                                         |
     +-------+--------------------------------------------------+
-    | #1    | Civi\FlexMailer\Listener\DefaultSender->onSend() |
+    | #1    | \Civi\Core\CiviEventDispatcher::delegateToUF()   |
+    | #2    | Civi\FlexMailer\Listener\DefaultSender->onSend() |
     +-------+--------------------------------------------------+
     ```
 
+!!! note "CMS Hooks"
+    It is *possible* to subscribe to these events in other ways. Note that each event has a listener named `delegateToUF()`
+    which will rebroadcast the event using a Drupal hook, WordPress action, or similar. For example, in a Drupal 7
+    module, one might say:
+
+    ```php
+    <?php
+    function mymodule_civicrm_flexmailer_walk(WalkBatchesEvent $event) { ... }
+    function mymodule_civicrm_flexmailer_compose(ComposeBatchEvent $event) { ... }
+    function mymodule_civicrm_flexmailer_send(SendBatchEvent $event) { ... }
+    ```
+
+    However, it's *strongly recommended* to use Symfony `EventDispatcher` notation with FlexMailer events.  This provides more transparency (via
+    `debug:event-dispatcher`), allows custom weights/priorities, and works intuitively with `stopPropagation()`.
 
 ## Unit tests
 

--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <url desc="Support">http://civicrm.stackexchange.com/</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2017-03-15</releaseDate>
-  <version>0.2-alpha2</version>
+  <releaseDate>2017-11-08</releaseDate>
+  <version>0.3-alpha1</version>
   <comments>
     FlexMailer is an email delivery engine which replaces the internal guts
     of CiviMail.  It is a drop-in replacement which enables *other* extensions

--- a/src/Event/BaseEvent.php
+++ b/src/Event/BaseEvent.php
@@ -25,12 +25,13 @@
  +--------------------------------------------------------------------+
  */
 namespace Civi\FlexMailer\Event;
+use Civi\Core\Event\GenericHookEvent;
 
 /**
  * Class BaseEvent
  * @package Civi\FlexMailer\Event
  */
-class BaseEvent extends \Symfony\Component\EventDispatcher\Event {
+class BaseEvent extends GenericHookEvent {
   /**
    * @var array
    *   An array which must define options:
@@ -46,6 +47,10 @@ class BaseEvent extends \Symfony\Component\EventDispatcher\Event {
    */
   public function __construct(array $context) {
     $this->context = $context;
+  }
+
+  public function getHookValues() {
+    return array($this);
   }
 
   /**

--- a/src/FlexMailer.php
+++ b/src/FlexMailer.php
@@ -93,10 +93,10 @@ class FlexMailer {
   const WEIGHT_ALTER = -1000;
   const WEIGHT_END = -2000;
 
-  const EVENT_RUN = 'civi.flexmailer.run';
-  const EVENT_WALK = 'civi.flexmailer.walk';
-  const EVENT_COMPOSE = 'civi.flexmailer.compose';
-  const EVENT_SEND = 'civi.flexmailer.send';
+  const EVENT_RUN = 'hook_civicrm_flexmailer_run';
+  const EVENT_WALK = 'hook_civicrm_flexmailer_walk';
+  const EVENT_COMPOSE = 'hook_civicrm_flexmailer_compose';
+  const EVENT_SEND = 'hook_civicrm_flexmailer_send';
 
   /**
    * @return array


### PR DESCRIPTION
(Pinging a few folks who've expressed interest in either Symfony Events or customizing the email delivery engine: @michaelmcandrew @tttp @nganivet @GinkgoFJG @mattwire @seanmadsen @seamuslee001.)

As discussed later in #1, `civicrm-core` has now [unified](https://github.com/civicrm/civicrm-core/pull/9949) the concepts of "hooks" and "Symfony events". Thus, the FlexMailer events could be presented as "hooks" while still supporting the more advanced features we need from Symfony  (such as `debug:event-dispatcher`, priorities, and `stopPropagation()`).

This PR renames the events from `civi.flexmailer.*` to `hook_civicrm_*` and thus makes it superficially work as a "hook". I did a cursory test to confirm that the hook fires and gives full access to the event, along the lines of:

```php
function mymodule_civicrm_flexmailer_compose(ComposeBatchEvent $event) { ... } 
```

So this is nice in that brings some harmony to the design.

However, I also feel that it's a bit misleading: FlexMailer is designed with the *expectation* that you'll do things like setting the priority of events (ie intentionally scheduling listener A before listener B). The process of delegating hooks to all the CMS's is reductive (it obfuscates these things), so I felt obliged to warn against it in the docs (below).

Which begs the question: if it's a bad idea to use CMS hook notation with these events, should we really support it?

Comments appreciated. If you'd just like to weigh-in with a quick gut reaction, feel free to do an emoji like:
 * ❤️ I love the word "hook"! Make the change to `hook_civicrm_flexmailer_*`.
 * 😕 I'm confused by features that you're not supposed to use. Keep `civi.flexmailer.*`.

I'm aiming to resolve the PR (accept it or reject it) by the end of the week (US/Pacific; ~48 hours).