### PR TITLE
CRM-21472 - Define `CheckSendableEvent`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ drop-in replacement which enables *other* extensions to provide richer email fea
 * [Introduction](docs/index.md)
 * [Installation](docs/install.md)
 * [Development](docs/develop/index.md)
+    * [CheckSendableEvent](docs/develop/CheckSendableEvent.md)
     * [WalkBatchesEvent](docs/develop/WalkBatchesEvent.md)
     * [ComposeBatchEvent](docs/develop/ComposeBatchEvent.md)
     * [SendBatchEvent](docs/develop/SendBatchEvent.md)

--- a/docs/develop/CheckSendableEvent.md
+++ b/docs/develop/CheckSendableEvent.md
@@ -1,0 +1,29 @@
+The `CheckSendableEvent` (`EVENT_CHECK_SENDABLE`) determines whether a draft mailing is fully specified for delivery.
+
+For example, some jurisdictions require that email blasts provide contact
+information for the organization (eg street address) and an opt-out links.
+By default, the check-sendable event will verify that this information is
+provided through a mail-merge token (eg `{action.unsubscribeUrl}`).
+
+The token validation logic depends on how the message has been encoded.  If
+you provide a new template language, you can implement suitable enforcement,
+e.g.
+
+
+```php
+<?php
+function mustache_civicrm_container($container) {
+  $container->addResource(new \Symfony\Component\Config\Resource\FileResource(__FILE__));
+  $container->findDefinition('dispatcher')->addMethodCall('addListener',
+    array(\Civi\FlexMailer\Validator::EVENT_CHECK_SENDABLE, '_mustache_check_sendable')
+  );
+}
+
+function _mustache_check_sendable(\Civi\FlexMailer\Event\CheckSendableEvent $e) {
+  if ($e->getMailing()->template_type !== 'mustache') return;
+
+  if (strpos('{{unsubscribeUrl}}', $e->getMailing()->body_html) === FALSE) {
+    $e->setError('body_html:unsubscribeUrl', E::ts('Please include the token {{unsubscribeUrl}}'));
+  }
+}
+```

--- a/docs/develop/CheckSendableEvent.md
+++ b/docs/develop/CheckSendableEvent.md
@@ -1,12 +1,12 @@
 The `CheckSendableEvent` (`EVENT_CHECK_SENDABLE`) determines whether a draft mailing is fully specified for delivery.
 
 For example, some jurisdictions require that email blasts provide contact
-information for the organization (eg street address) and an opt-out links.
+information for the organization (eg street address) and an opt-out link.
 By default, the check-sendable event will verify that this information is
 provided through a mail-merge token (eg `{action.unsubscribeUrl}`).
 
 The token validation logic depends on how the message has been encoded.  If
-you provide a new template language, you can implement suitable enforcement,
+you provide a new template language, you can implement new enforcement logic,
 e.g.
 
 

--- a/docs/develop/index.md
+++ b/docs/develop/index.md
@@ -92,10 +92,25 @@ There are a few tricks for manipulating the pipeline:
     Of course, this change needs to be made before the listener runs. You might use a global hook (like `hook_civicrm_config`), or you might
     have your own listener which disables `civi_flexmailer_bounce_tracker` and adds its own bounce-tracking.
 
+    Most FlexMailer services support `setActive()`, which enables you to completely replace them.
+
+    Additionally, some services have their own richer methods. In this example, we modify the list of required tokens:
+
+    ```php
+    <?php
+    $tokens = \Civi::service('civi_flexmailer_required_tokens')
+      ->getRequiredTokens();
+
+    unset($tokens['domain.address']);
+
+    \Civi::service('civi_flexmailer_required_tokens')
+      ->setRequiredTokens($tokens);
+    ```
 
 ## Services
 
 Most features in FlexMailer are implemented by *services*, and you can override or manipulate these features if you understand the corresponding service.
+For more detailed information about how to manipulate a service, consult its docblocks.
 
 * Listener services (`CheckSendableEvent`)
      * `civi_flexmailer_required_fields` (`RequiredFields.php`): Check for fields like "Subject" and "From".

--- a/docs/develop/index.md
+++ b/docs/develop/index.md
@@ -14,8 +14,9 @@ $ phpunit4
     If this is unfamiliar, you can read [a general introduction to Symfony events](http://symfony.com/doc/2.7/components/event_dispatcher.html)
     or [a specific introduction about CiviCRM and Symfony events](https://docs.civicrm.org/dev/en/latest/hooks/setup/symfony/).
 
-FlexMailer is an *event* based delivery system. It defines three primary events:
+FlexMailer is an *event* based delivery system. It defines a few events:
 
+* [CheckSendableEvent](CheckSendableEvent.md): In this event, one examines a draft mailing to determine if it is complete enough to deliver.
 * [WalkBatchesEvent](WalkBatchesEvent.md): In this event, one examines the recipient list and pulls out a subset for whom you want to send email.
 * [ComposeBatchEvent](ComposeBatchEvent.md): In this event, one examines the mail content and the list of recipients -- then composes a batch of fully-formed email messages.
 * [SendBatchEvent](SendBatchEvent.md): In this event, one takes a batch of fully-formed email messages and delivers the messages.
@@ -26,6 +27,14 @@ this with the CLI command, `cv`:
 
 ```
 $ cv debug:event-dispatcher /flexmail/
+[Event] civi.flexmailer.checkSendable
++-------+------------------------------------------------------------+
+| Order | Callable                                                   |
++-------+------------------------------------------------------------+
+| #1    | Civi\FlexMailer\Listener\RequiredFields->onCheckSendable() |
+| #2    | Civi\FlexMailer\Listener\RequiredTokens->onCheckSendable() |
++-------+------------------------------------------------------------+
+
 [Event] civi.flexmailer.walk
 +-------+---------------------------------------------------+
 | Order | Callable                                          |
@@ -88,6 +97,9 @@ There are a few tricks for manipulating the pipeline:
 
 Most features in FlexMailer are implemented by *services*, and you can override or manipulate these features if you understand the corresponding service.
 
+* Listener services (`CheckSendableEvent`)
+     * `civi_flexmailer_required_fields` (`RequiredFields.php`): Check for fields like "Subject" and "From".
+     * `civi_flexmailer_required_tokens` (`RequiredTokens.php`): Check for tokens like `{action.unsubscribeUrl}` (in `traditional` mailings).
 * Listener services (`WalkBatchesEvent`)
      * `civi_flexmailer_default_batcher` (`DefaultBatcher.php`): Split the recipient list into smaller batches (per CiviMail settings)
 * Listener services (`ComposeBatchEvent`)

--- a/flexmailer.php
+++ b/flexmailer.php
@@ -7,6 +7,7 @@
  */
 
 define('CIVICRM_FLEXMAILER_HACK_DELIVER', '\Civi\FlexMailer\FlexMailer::createAndRun');
+define('CIVICRM_FLEXMAILER_HACK_SENDABLE', '\Civi\FlexMailer\Validator::createAndRun');
 //define('CIVICRM_FLEXMAILER_HACK_SERVICES', '\Civi\FlexMailer\Services::registerServices');
 //define('CIVICRM_FLEXMAILER_HACK_LISTENERS', '\Civi\FlexMailer\Services::registerListeners');
 

--- a/flexmailer.php
+++ b/flexmailer.php
@@ -8,6 +8,7 @@
 
 define('CIVICRM_FLEXMAILER_HACK_DELIVER', '\Civi\FlexMailer\FlexMailer::createAndRun');
 define('CIVICRM_FLEXMAILER_HACK_SENDABLE', '\Civi\FlexMailer\Validator::createAndRun');
+define('CIVICRM_FLEXMAILER_HACK_REQUIRED_TOKENS', 'call://civi_flexmailer_required_tokens/getRequiredTokens');
 //define('CIVICRM_FLEXMAILER_HACK_SERVICES', '\Civi\FlexMailer\Services::registerServices');
 //define('CIVICRM_FLEXMAILER_HACK_LISTENERS', '\Civi\FlexMailer\Services::registerListeners');
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,7 @@ pages:
 - Installation: install.md
 - Development:
   - Overview: develop/index.md
+  - CheckSendableEvent: develop/CheckSendableEvent.md
   - WalkBatchesEvent: develop/WalkBatchesEvent.md
   - ComposeBatchEvent: develop/ComposeBatchEvent.md
   - SendBatchEvent: develop/SendBatchEvent.md

--- a/src/Event/CheckSendableEvent.php
+++ b/src/Event/CheckSendableEvent.php
@@ -79,4 +79,25 @@ class CheckSendableEvent extends \Symfony\Component\EventDispatcher\Event {
     return $this->errors;
   }
 
+  /**
+   * Get the full, combined content of the header, body, and footer.
+   *
+   * @param string $field
+   *   Name of the field -- either 'body_text' or 'body_html'.
+   * @return string|NULL
+   *   Either the combined header+body+footer, or NULL if there is no body.
+   */
+  public function getFullBody($field) {
+    if ($field !== 'body_text' && $field !== 'body_html') {
+      throw new \RuntimeException("getFullBody() only supports body_text and body_html");
+    }
+    $mailing = $this->getMailing();
+    $header = $mailing->header_id && $mailing->header_id != 'null' ? \CRM_Mailing_BAO_Component::findById($mailing->header_id) : NULL;
+    $footer = $mailing->footer_id && $mailing->footer_id != 'null' ? \CRM_Mailing_BAO_Component::findById($mailing->footer_id) : NULL;
+    if (empty($mailing->{$field})) {
+      return NULL;
+    }
+    return ($header ? $header->{$field} : '') . $mailing->{$field} . ($footer ? $footer->{$field} : '');
+  }
+
 }

--- a/src/Event/CheckSendableEvent.php
+++ b/src/Event/CheckSendableEvent.php
@@ -1,0 +1,82 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2017                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+namespace Civi\FlexMailer\Event;
+
+/**
+ * Class CheckSendableEvent
+ * @package Civi\FlexMailer\Event
+ */
+class CheckSendableEvent extends \Symfony\Component\EventDispatcher\Event {
+
+  /**
+   * @var array
+   *   An array which must define options:
+   *     - mailing: \CRM_Mailing_BAO_Mailing
+   *     - attachments: array
+   */
+  public $context;
+
+  /**
+   * @var array
+   *   A list of error messages.
+   *   Ex: array('subject' => 'The Subject field is blank').
+   *   Example keys: 'subject', 'name', 'from_name', 'from_email', 'body', 'body_html:unsubscribeUrl'.
+   */
+  protected $errors = array();
+
+  /**
+   * CheckSendableEvent constructor.
+   * @param array $context
+   */
+  public function __construct(array $context) {
+    $this->context = $context;
+  }
+
+  /**
+   * @return \CRM_Mailing_BAO_Mailing
+   */
+  public function getMailing() {
+    return $this->context['mailing'];
+  }
+
+  /**
+   * @return array|NULL
+   */
+  public function getAttachments() {
+    return $this->context['attachments'];
+  }
+
+  public function setError($key, $message) {
+    $this->errors[$key] = $message;
+    return $this;
+  }
+
+  public function getErrors() {
+    return $this->errors;
+  }
+
+}

--- a/src/Listener/RequiredFields.php
+++ b/src/Listener/RequiredFields.php
@@ -1,0 +1,88 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2017                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+namespace Civi\FlexMailer\Listener;
+
+use CRM_Flexmailer_ExtensionUtil as E;
+use Civi\FlexMailer\Event\CheckSendableEvent;
+
+class RequiredFields extends BaseListener {
+
+  private $fields = array(
+    'subject',
+    'name',
+    'from_name',
+    'from_email',
+    '(body_html|body_text)',
+  );
+
+  /**
+   * Check for required fields.
+   *
+   * @param \Civi\FlexMailer\Event\CheckSendableEvent $e
+   */
+  public function onCheckSendable(CheckSendableEvent $e) {
+    if (!$this->isActive()) {
+      return;
+    }
+
+    foreach ($this->fields as $field) {
+      if ($field{0} === '(') {
+        $alternatives = explode('|', substr($field, 1, -1));
+        $fieldTitle = implode(' or ', array_map(function ($x) {
+          return "\"$x\"";
+        }, $alternatives));
+        $found = $this->hasAny($e->getMailing(), $alternatives);
+      }
+      else {
+        $fieldTitle = "\"$field\"";
+        $found = !empty($e->getMailing()->{$field});
+      }
+
+      if (!$found) {
+        $e->setError($field, E::ts('Field %1 is required.', array(
+          1 => $fieldTitle,
+        )));
+      }
+      unset($found);
+    }
+  }
+
+  /**
+   * @param $mailing
+   * @param $alternatives
+   * @return bool
+   */
+  protected function hasAny($mailing, $alternatives) {
+    foreach ($alternatives as $alternative) {
+      if (!empty($mailing->{$alternative})) {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+}

--- a/src/Listener/RequiredFields.php
+++ b/src/Listener/RequiredFields.php
@@ -29,15 +29,27 @@ namespace Civi\FlexMailer\Listener;
 use CRM_Flexmailer_ExtensionUtil as E;
 use Civi\FlexMailer\Event\CheckSendableEvent;
 
+/**
+ * Class RequiredFields
+ * @package Civi\FlexMailer\Listener
+ *
+ * The RequiredFields listener checks that all mandatory fields have a value.
+ */
 class RequiredFields extends BaseListener {
 
-  private $fields = array(
-    'subject',
-    'name',
-    'from_name',
-    'from_email',
-    '(body_html|body_text)',
-  );
+  /**
+   * @var array
+   *   Ex: array('subject', 'from_name', '(body_html|body_text)').
+   */
+  private $fields;
+
+  /**
+   * RequiredFields constructor.
+   * @param array $fields
+   */
+  public function __construct( $fields) {
+    $this->fields = $fields;
+  }
 
   /**
    * Check for required fields.
@@ -50,6 +62,7 @@ class RequiredFields extends BaseListener {
     }
 
     foreach ($this->fields as $field) {
+      // Parentheses indicate multiple options. Ex: '(body_html|body_text)'
       if ($field{0} === '(') {
         $alternatives = explode('|', substr($field, 1, -1));
         $fieldTitle = implode(' or ', array_map(function ($x) {
@@ -72,17 +85,41 @@ class RequiredFields extends BaseListener {
   }
 
   /**
-   * @param $mailing
-   * @param $alternatives
+   * Determine if $object has any of the given properties.
+   *
+   * @param mixed $object
+   * @param array $alternatives
    * @return bool
    */
-  protected function hasAny($mailing, $alternatives) {
+  protected function hasAny($object, $alternatives) {
     foreach ($alternatives as $alternative) {
-      if (!empty($mailing->{$alternative})) {
+      if (!empty($object->{$alternative})) {
         return TRUE;
       }
     }
     return FALSE;
+  }
+
+  /**
+   * Get the list of required fields.
+   *
+   * @return array
+   *   Ex: array('subject', 'from_name', '(body_html|body_text)').
+   */
+  public function getFields() {
+    return $this->fields;
+  }
+
+  /**
+   * Set the list of required fields.
+   *
+   * @param array $fields
+   *   Ex: array('subject', 'from_name', '(body_html|body_text)').
+   * @return RequiredFields
+   */
+  public function setFields($fields) {
+    $this->fields = $fields;
+    return $this;
   }
 
 }

--- a/src/Listener/RequiredTokens.php
+++ b/src/Listener/RequiredTokens.php
@@ -39,6 +39,8 @@ use Civi\FlexMailer\Event\CheckSendableEvent;
  */
 class RequiredTokens extends BaseListener {
 
+  private $requiredTokens;
+
   /**
    * @var array
    *
@@ -52,6 +54,15 @@ class RequiredTokens extends BaseListener {
    */
   public function __construct() {
     $this->templateTypes = array('traditional');
+    $this->requiredTokens = array(
+      'domain.address' => ts("Domain address - displays your organization's postal address."),
+      'action.optOutUrl or action.unsubscribeUrl' => array(
+        'action.optOut' => ts("'Opt out via email' - displays an email address for recipients to opt out of receiving emails from your organization."),
+        'action.optOutUrl' => ts("'Opt out via web page' - creates a link for recipients to click if they want to opt out of receiving emails from your organization. Alternatively, you can include the 'Opt out via email' token."),
+        'action.unsubscribe' => ts("'Unsubscribe via email' - displays an email address for recipients to unsubscribe from the specific mailing list used to send this message."),
+        'action.unsubscribeUrl' => ts("'Unsubscribe via web page' - creates a link for recipients to unsubscribe from the specific mailing list used to send this message. Alternatively, you can include the 'Unsubscribe via email' token or one of the Opt-out tokens."),
+      ),
+    );
   }
 
   /**
@@ -75,15 +86,51 @@ class RequiredTokens extends BaseListener {
       if (empty($str)) {
         continue;
       }
-      $err = \CRM_Utils_Token::requiredTokens($str);
-      if ($err !== TRUE) {
-        foreach ($err as $token => $desc) {
-          $e->setError("{$field}:{$token}", E::ts('This message is missing a required token - {%1}: %2',
-            array(1 => $token, 2 => $desc)
-          ));
+      foreach ($this->findMissingTokens($str) as $token => $desc) {
+        $e->setError("{$field}:{$token}", E::ts('This message is missing a required token - {%1}: %2',
+          array(1 => $token, 2 => $desc)
+        ));
+      }
+    }
+  }
+
+  public function findMissingTokens($str) {
+    $missing = array();
+    foreach ($this->getRequiredTokens() as $token => $value) {
+      if (!is_array($value)) {
+        if (!preg_match('/(^|[^\{])' . preg_quote('{' . $token . '}') . '/', $str)) {
+          $missing[$token] = $value;
+        }
+      }
+      else {
+        $present = FALSE;
+        $desc = NULL;
+        foreach ($value as $t => $d) {
+          $desc = $d;
+          if (preg_match('/(^|[^\{])' . preg_quote('{' . $t . '}') . '/', $str)) {
+            $present = TRUE;
+          }
+        }
+        if (!$present) {
+          $missing[$token] = $desc;
         }
       }
     }
+    return $missing;
+  }
+
+  /**
+   * @return array
+   */
+  public function getRequiredTokens() {
+    return $this->requiredTokens;
+  }
+
+  /**
+   * @param array $requiredTokens
+   */
+  public function setRequiredTokens($requiredTokens) {
+    $this->requiredTokens = $requiredTokens;
   }
 
   /**

--- a/src/Listener/RequiredTokens.php
+++ b/src/Listener/RequiredTokens.php
@@ -39,6 +39,10 @@ use Civi\FlexMailer\Event\CheckSendableEvent;
  */
 class RequiredTokens extends BaseListener {
 
+  /**
+   * @var array
+   *   Ex: array('domain.address' => ts('The organizational postal address'))
+   */
   private $requiredTokens;
 
   /**
@@ -51,18 +55,15 @@ class RequiredTokens extends BaseListener {
 
   /**
    * RequiredTokens constructor.
+   *
+   * @param array $templateTypes
+   *   Ex: array('traditional').
+   * @param array $requiredTokens
+   *   Ex: array('domain.address' => ts('The organizational postal address'))
    */
-  public function __construct() {
-    $this->templateTypes = array('traditional');
-    $this->requiredTokens = array(
-      'domain.address' => ts("Domain address - displays your organization's postal address."),
-      'action.optOutUrl or action.unsubscribeUrl' => array(
-        'action.optOut' => ts("'Opt out via email' - displays an email address for recipients to opt out of receiving emails from your organization."),
-        'action.optOutUrl' => ts("'Opt out via web page' - creates a link for recipients to click if they want to opt out of receiving emails from your organization. Alternatively, you can include the 'Opt out via email' token."),
-        'action.unsubscribe' => ts("'Unsubscribe via email' - displays an email address for recipients to unsubscribe from the specific mailing list used to send this message."),
-        'action.unsubscribeUrl' => ts("'Unsubscribe via web page' - creates a link for recipients to unsubscribe from the specific mailing list used to send this message. Alternatively, you can include the 'Unsubscribe via email' token or one of the Opt-out tokens."),
-      ),
-    );
+  public function __construct($templateTypes, $requiredTokens) {
+    $this->templateTypes = $templateTypes;
+    $this->requiredTokens = $requiredTokens;
   }
 
   /**
@@ -121,6 +122,7 @@ class RequiredTokens extends BaseListener {
 
   /**
    * @return array
+   *   Ex: array('domain.address' => ts('The organizational postal address'))
    */
   public function getRequiredTokens() {
     return $this->requiredTokens;
@@ -128,9 +130,12 @@ class RequiredTokens extends BaseListener {
 
   /**
    * @param array $requiredTokens
+   *   Ex: array('domain.address' => ts('The organizational postal address'))
+   * @return RequiredTokens
    */
   public function setRequiredTokens($requiredTokens) {
     $this->requiredTokens = $requiredTokens;
+    return $this;
   }
 
   /**

--- a/src/Listener/RequiredTokens.php
+++ b/src/Listener/RequiredTokens.php
@@ -1,0 +1,121 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2017                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+namespace Civi\FlexMailer\Listener;
+
+use CRM_Flexmailer_ExtensionUtil as E;
+use Civi\FlexMailer\Event\CheckSendableEvent;
+
+/**
+ * Class RequiredTokens
+ * @package Civi\FlexMailer\Listener
+ *
+ * The RequiredTokens listener checks draft mailings for traditional
+ * CiviMail tokens like `{action.unsubscribeUrl}`, which are often required
+ * to comply with anti-spam regulations.
+ */
+class RequiredTokens extends BaseListener {
+
+  /**
+   * @var array
+   *
+   * List of template-types for which we are capable of enforcing token
+   * requirements.
+   */
+  private $templateTypes;
+
+  /**
+   * RequiredTokens constructor.
+   */
+  public function __construct() {
+    $this->templateTypes = array('traditional');
+  }
+
+  /**
+   * Check for required fields.
+   *
+   * @param \Civi\FlexMailer\Event\CheckSendableEvent $e
+   */
+  public function onCheckSendable(CheckSendableEvent $e) {
+    if (!$this->isActive()) {
+      return;
+    }
+    if (\Civi::settings()->get('disable_mandatory_tokens_check')) {
+      return;
+    }
+    if (!in_array($e->getMailing()->template_type, $this->templateTypes)) {
+      return;
+    }
+
+    foreach (array('body_html', 'body_text') as $field) {
+      $str = $e->getFullBody($field);
+      if (empty($str)) {
+        continue;
+      }
+      $err = \CRM_Utils_Token::requiredTokens($str);
+      if ($err !== TRUE) {
+        foreach ($err as $token => $desc) {
+          $e->setError("{$field}:{$token}", E::ts('This message is missing a required token - {%1}: %2',
+            array(1 => $token, 2 => $desc)
+          ));
+        }
+      }
+    }
+  }
+
+  /**
+   * @return array
+   *   Ex: array('traditional').
+   */
+  public function getTemplateTypes() {
+    return $this->templateTypes;
+  }
+
+  /**
+   * Set the list of template-types for which we check tokens.
+   *
+   * @param array $templateTypes
+   *   Ex: array('traditional').
+   * @return RequiredTokens
+   */
+  public function setTemplateTypes($templateTypes) {
+    $this->templateTypes = $templateTypes;
+    return $this;
+  }
+
+  /**
+   * Add to the list of template-types for which we check tokens.
+   *
+   * @param array $templateTypes
+   *   Ex: array('traditional').
+   * @return RequiredTokens
+   */
+  public function addTemplateTypes($templateTypes) {
+    $this->templateTypes = array_unique(array_merge($this->templateTypes, $templateTypes));
+    return $this;
+  }
+
+}

--- a/src/Services.php
+++ b/src/Services.php
@@ -49,6 +49,7 @@ class Services {
       ->setFactory(array(__CLASS__, 'createApiOverrides'));
 
     $container->setDefinition('civi_flexmailer_required_fields', new Definition('Civi\FlexMailer\Listener\RequiredFields'));
+    $container->setDefinition('civi_flexmailer_required_tokens', new Definition('Civi\FlexMailer\Listener\RequiredTokens'));
 
     $container->setDefinition('civi_flexmailer_abdicator', new Definition('Civi\FlexMailer\Listener\Abdicator'));
     $container->setDefinition('civi_flexmailer_default_batcher', new Definition('Civi\FlexMailer\Listener\DefaultBatcher'));
@@ -91,7 +92,8 @@ class Services {
   protected static function getListenerSpecs() {
     $listenerSpecs = array();
 
-    $listenerSpecs[] = array(Validator::EVENT_CHECK_SENDABLE, array('civi_flexmailer_required_fields', 'onCheckSendable'), FM::WEIGHT_PREPARE);
+    $listenerSpecs[] = array(Validator::EVENT_CHECK_SENDABLE, array('civi_flexmailer_required_fields', 'onCheckSendable'), FM::WEIGHT_MAIN);
+    $listenerSpecs[] = array(Validator::EVENT_CHECK_SENDABLE, array('civi_flexmailer_required_tokens', 'onCheckSendable'), FM::WEIGHT_MAIN);
 
     $listenerSpecs[] = array(FM::EVENT_RUN, array('civi_flexmailer_default_composer', 'onRun'), FM::WEIGHT_MAIN);
     $listenerSpecs[] = array(FM::EVENT_RUN, array('civi_flexmailer_abdicator', 'onRun'), FM::WEIGHT_END);

--- a/src/Services.php
+++ b/src/Services.php
@@ -48,8 +48,27 @@ class Services {
     $container->setDefinition('civi_flexmailer_api_overrides', new Definition('Civi\API\Provider\ProviderInterface'))
       ->setFactory(array(__CLASS__, 'createApiOverrides'));
 
-    $container->setDefinition('civi_flexmailer_required_fields', new Definition('Civi\FlexMailer\Listener\RequiredFields'));
-    $container->setDefinition('civi_flexmailer_required_tokens', new Definition('Civi\FlexMailer\Listener\RequiredTokens'));
+    $container->setDefinition('civi_flexmailer_required_fields', new Definition('Civi\FlexMailer\Listener\RequiredFields', array(
+      array(
+        'subject',
+        'name',
+        'from_name',
+        'from_email',
+        '(body_html|body_text)',
+      ),
+    )));
+    $container->setDefinition('civi_flexmailer_required_tokens', new Definition('Civi\FlexMailer\Listener\RequiredTokens', array(
+      array('traditional'),
+      array(
+        'domain.address' => ts("Domain address - displays your organization's postal address."),
+        'action.optOutUrl or action.unsubscribeUrl' => array(
+          'action.optOut' => ts("'Opt out via email' - displays an email address for recipients to opt out of receiving emails from your organization."),
+          'action.optOutUrl' => ts("'Opt out via web page' - creates a link for recipients to click if they want to opt out of receiving emails from your organization. Alternatively, you can include the 'Opt out via email' token."),
+          'action.unsubscribe' => ts("'Unsubscribe via email' - displays an email address for recipients to unsubscribe from the specific mailing list used to send this message."),
+          'action.unsubscribeUrl' => ts("'Unsubscribe via web page' - creates a link for recipients to unsubscribe from the specific mailing list used to send this message. Alternatively, you can include the 'Unsubscribe via email' token or one of the Opt-out tokens."),
+        ),
+      ),
+    )));
 
     $container->setDefinition('civi_flexmailer_abdicator', new Definition('Civi\FlexMailer\Listener\Abdicator'));
     $container->setDefinition('civi_flexmailer_default_batcher', new Definition('Civi\FlexMailer\Listener\DefaultBatcher'));

--- a/src/Services.php
+++ b/src/Services.php
@@ -48,6 +48,8 @@ class Services {
     $container->setDefinition('civi_flexmailer_api_overrides', new Definition('Civi\API\Provider\ProviderInterface'))
       ->setFactory(array(__CLASS__, 'createApiOverrides'));
 
+    $container->setDefinition('civi_flexmailer_required_fields', new Definition('Civi\FlexMailer\Listener\RequiredFields'));
+
     $container->setDefinition('civi_flexmailer_abdicator', new Definition('Civi\FlexMailer\Listener\Abdicator'));
     $container->setDefinition('civi_flexmailer_default_batcher', new Definition('Civi\FlexMailer\Listener\DefaultBatcher'));
     $container->setDefinition('civi_flexmailer_default_composer', new Definition('Civi\FlexMailer\Listener\DefaultComposer'));
@@ -88,6 +90,8 @@ class Services {
    */
   protected static function getListenerSpecs() {
     $listenerSpecs = array();
+
+    $listenerSpecs[] = array(Validator::EVENT_CHECK_SENDABLE, array('civi_flexmailer_required_fields', 'onCheckSendable'), FM::WEIGHT_PREPARE);
 
     $listenerSpecs[] = array(FM::EVENT_RUN, array('civi_flexmailer_default_composer', 'onRun'), FM::WEIGHT_MAIN);
     $listenerSpecs[] = array(FM::EVENT_RUN, array('civi_flexmailer_abdicator', 'onRun'), FM::WEIGHT_END);

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -1,0 +1,86 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2017                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+namespace Civi\FlexMailer;
+
+use Civi\FlexMailer\Event\CheckSendableEvent;
+use \Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * Class Validator
+ * @package Civi\FlexMailer
+ *
+ * The *validator* determines whether a mailing is completely specified
+ * (sendable). If not delivery.
+ */
+class Validator {
+
+  const EVENT_CHECK_SENDABLE = 'civi.flexmailer.checkSendable';
+
+  /**
+   * @param \CRM_Mailing_DAO_Mailing $mailing
+   *   The mailing which may or may not be sendable.
+   * @return array
+   *   List of error messages.
+   */
+  public static function createAndRun($mailing) {
+    $validator = new \Civi\FlexMailer\Validator();
+    return $validator->run(array(
+      'mailing' => $mailing,
+      'attachments' => \CRM_Core_BAO_File::getEntityFile('civicrm_mailing', $mailing->id),
+    ));
+  }
+
+  /**
+   * @var EventDispatcherInterface
+   */
+  private $dispatcher;
+
+  /**
+   * FlexMailer constructor.
+   * @param EventDispatcherInterface $dispatcher
+   */
+  public function __construct(EventDispatcherInterface $dispatcher = NULL) {
+    $this->dispatcher = $dispatcher ? $dispatcher : \Civi::service('dispatcher');
+  }
+
+  /**
+   * @param array $context
+   *   An array which must define options:
+   *     - mailing: \CRM_Mailing_BAO_Mailing
+   *     - attachments: array
+   * @return array
+   *   List of error messages.
+   *   Ex: array('subject' => 'The Subject field is blank').
+   *   Example keys: 'subject', 'name', 'from_name', 'from_email', 'body', 'body_html:unsubscribeUrl'.
+   */
+  public function run($context) {
+    $checkSendable = new CheckSendableEvent($context);
+    $this->dispatcher->dispatch(static::EVENT_CHECK_SENDABLE, $checkSendable);
+    return $checkSendable->getErrors();
+  }
+
+}

--- a/tests/phpunit/Civi/FlexMailer/ValidatorTest.php
+++ b/tests/phpunit/Civi/FlexMailer/ValidatorTest.php
@@ -79,8 +79,8 @@ class ValidatorTest extends \CiviUnitTestCase {
     $es[] = array(
       array_merge($defaults, array('body_html' => 'Muahaha. I omit the mandatory tokens!')),
       array(
-        'body_html:domain.address'  => '/This message is missing/',
-        'body_html:action.optOutUrl or action.unsubscribeUrl' => '/This message is missing/',
+        'body_html:domain.address'  => '/This message is missing.*postal address/',
+        'body_html:action.optOutUrl or action.unsubscribeUrl' => '/This message is missing.*Unsubscribe via web page/',
       ),
     );
     $es[] = array(

--- a/tests/phpunit/Civi/FlexMailer/ValidatorTest.php
+++ b/tests/phpunit/Civi/FlexMailer/ValidatorTest.php
@@ -1,0 +1,95 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2017                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+namespace Civi\FlexMailer;
+
+class ValidatorTest extends \CiviUnitTestCase {
+
+  public function setUp() {
+    // Activate before transactions are setup.
+    $manager = \CRM_Extension_System::singleton()->getManager();
+    if ($manager->getStatus('org.civicrm.flexmailer') !== \CRM_Extension_Manager::STATUS_INSTALLED) {
+      $manager->install(array('org.civicrm.flexmailer'));
+    }
+
+    parent::setUp();
+    \CRM_Core_BAO_Setting::setItem(TRUE, 'Mailing Preferences', 'experimentalFlexMailerEngine');
+  }
+
+  public function getExamples() {
+    $defaults = array(
+      'id' => 123,
+      'subject' => 'Default subject',
+      'name' => 'Default name',
+      'from_name' => 'Default sender',
+      'from_email' => 'default@example.org',
+      'body_html' => '<html>Default HTML body</html>',
+      'body_text' => 'Default text body',
+      'template_type' => 'traditional',
+      'template_options' => array(),
+    );
+
+    $es = array();
+    $es[] = array(
+      array_merge($defaults, array('subject' => NULL)),
+      array('subject' => 'Field "subject" is required.'),
+    );
+    $es[] = array(
+      array_merge($defaults, array('subject' => NULL, 'from_name' => NULL)),
+      array(
+        'subject' => 'Field "subject" is required.',
+        'from_name' => 'Field "from_name" is required.',
+      ),
+    );
+    $es[] = array(
+      array_merge($defaults, array('body_html' => 'a', 'body_text' => NULL)),
+      array(),
+    );
+    $es[] = array(
+      array_merge($defaults, array('body_html' => NULL, 'body_text' => 'b')),
+      array(),
+    );
+    $es[] = array(
+      array_merge($defaults, array('body_html' => NULL, 'body_text' => NULL)),
+      array('(body_html|body_text)' => 'Field "body_html" or "body_text" is required.'),
+    );
+    return $es;
+  }
+
+  /**
+   * @param array $mailingData
+   *   Mailing content (per CRM_Mailing_DAO_Mailing) as an array.
+   * @param array $expectedErrors
+   * @dataProvider getExamples
+   */
+  public function testExamples($mailingData, $expectedErrors) {
+    $mailing = new \CRM_Mailing_DAO_Mailing();
+    $mailing->copyValues($mailingData);
+    $actualErrors = Validator::createAndRun($mailing);
+    $this->assertEquals($actualErrors, $expectedErrors);
+  }
+
+}

--- a/tests/phpunit/Civi/FlexMailer/ValidatorTest.php
+++ b/tests/phpunit/Civi/FlexMailer/ValidatorTest.php
@@ -46,8 +46,8 @@ class ValidatorTest extends \CiviUnitTestCase {
       'name' => 'Default name',
       'from_name' => 'Default sender',
       'from_email' => 'default@example.org',
-      'body_html' => '<html>Default HTML body</html>',
-      'body_text' => 'Default text body',
+      'body_html' => '<html>Default HTML body {action.unsubscribeUrl} {domain.address}</html>',
+      'body_text' => 'Default text body {action.unsubscribeUrl} {domain.address}',
       'template_type' => 'traditional',
       'template_options' => array(),
     );
@@ -55,26 +55,37 @@ class ValidatorTest extends \CiviUnitTestCase {
     $es = array();
     $es[] = array(
       array_merge($defaults, array('subject' => NULL)),
-      array('subject' => 'Field "subject" is required.'),
+      array('subject' => '/Field "subject" is required./'),
     );
     $es[] = array(
       array_merge($defaults, array('subject' => NULL, 'from_name' => NULL)),
       array(
-        'subject' => 'Field "subject" is required.',
-        'from_name' => 'Field "from_name" is required.',
+        'subject' => '/Field "subject" is required./',
+        'from_name' => '/Field "from_name" is required./',
       ),
     );
     $es[] = array(
-      array_merge($defaults, array('body_html' => 'a', 'body_text' => NULL)),
+      array_merge($defaults, array('body_text' => NULL)),
       array(),
     );
     $es[] = array(
-      array_merge($defaults, array('body_html' => NULL, 'body_text' => 'b')),
+      array_merge($defaults, array('body_html' => NULL)),
       array(),
     );
     $es[] = array(
       array_merge($defaults, array('body_html' => NULL, 'body_text' => NULL)),
-      array('(body_html|body_text)' => 'Field "body_html" or "body_text" is required.'),
+      array('(body_html|body_text)' => '/Field "body_html" or "body_text" is required./'),
+    );
+    $es[] = array(
+      array_merge($defaults, array('body_html' => 'Muahaha. I omit the mandatory tokens!')),
+      array(
+        'body_html:domain.address'  => '/This message is missing/',
+        'body_html:action.optOutUrl or action.unsubscribeUrl' => '/This message is missing/',
+      ),
+    );
+    $es[] = array(
+      array_merge($defaults, array('body_html' => 'I omit the mandatory tokens, but checking them is someone else\'s job!', 'template_type' => 'esperanto')),
+      array(),
     );
     return $es;
   }
@@ -89,7 +100,13 @@ class ValidatorTest extends \CiviUnitTestCase {
     $mailing = new \CRM_Mailing_DAO_Mailing();
     $mailing->copyValues($mailingData);
     $actualErrors = Validator::createAndRun($mailing);
-    $this->assertEquals($actualErrors, $expectedErrors);
+    $this->assertEquals(
+      array_keys($actualErrors),
+      array_keys($expectedErrors)
+    );
+    foreach ($expectedErrors as $key => $pat) {
+      $this->assertRegExp($pat, $actualErrors[$key], "Error for \"$key\" should match pattern");
+    }
   }
 
 }


### PR DESCRIPTION
Per [CRM-21472](https://issues.civicrm.org/jira/browse/CRM-21472), the Mosaico UI has a problem wherein the final token-validation fails because it's formatted a bit differently.

This PR adds several elements to FlexMailer to make it possible to correctly handle the token-validation. Key elements:

 * Override core's token validation
 * Expose services for `RequiredFields` and `RequiredTokens`. Each service is configurable.
 * Expose `CheckSendableEvent`. This event uses `RequiredFields` and `RequiredTokens`. You can, however, add more listeners to handle the validation differently.
 * Update the FlexMailer developer docs

Notes:
 * This depends on a core PR, which I'll open and cross-link momentarily.
 * In absence of core's PR, the new code should all be inert.