### PR TITLE
On `traditional` mailings, abdicate vis-a-vis checkSendable

### DIFF
--- a/docs/develop/index.md
+++ b/docs/develop/index.md
@@ -31,8 +31,9 @@ $ cv debug:event-dispatcher /flexmail/
 +-------+------------------------------------------------------------+
 | Order | Callable                                                   |
 +-------+------------------------------------------------------------+
-| #1    | Civi\FlexMailer\Listener\RequiredFields->onCheckSendable() |
-| #2    | Civi\FlexMailer\Listener\RequiredTokens->onCheckSendable() |
+| #1    | Civi\FlexMailer\Listener\Abdicator->onCheckSendable()      |
+| #2    | Civi\FlexMailer\Listener\RequiredFields->onCheckSendable() |
+| #3    | Civi\FlexMailer\Listener\RequiredTokens->onCheckSendable() |
 +-------+------------------------------------------------------------+
 
 [Event] civi.flexmailer.walk

--- a/src/FlexMailer.php
+++ b/src/FlexMailer.php
@@ -88,6 +88,7 @@ use \Symfony\Component\EventDispatcher\EventDispatcherInterface;
  */
 class FlexMailer {
 
+  const WEIGHT_START = 2000;
   const WEIGHT_PREPARE = 1000;
   const WEIGHT_MAIN = 0;
   const WEIGHT_ALTER = -1000;

--- a/src/Services.php
+++ b/src/Services.php
@@ -111,6 +111,7 @@ class Services {
   protected static function getListenerSpecs() {
     $listenerSpecs = array();
 
+    $listenerSpecs[] = array(Validator::EVENT_CHECK_SENDABLE, array('civi_flexmailer_abdicator', 'onCheckSendable'), FM::WEIGHT_START);
     $listenerSpecs[] = array(Validator::EVENT_CHECK_SENDABLE, array('civi_flexmailer_required_fields', 'onCheckSendable'), FM::WEIGHT_MAIN);
     $listenerSpecs[] = array(Validator::EVENT_CHECK_SENDABLE, array('civi_flexmailer_required_tokens', 'onCheckSendable'), FM::WEIGHT_MAIN);
 


### PR DESCRIPTION
We currently abdicate vis-a-vis delivery.  The checkSendable process should
behave the same.