### PR TITLE
Port civicrm-core SMTP retry logic fixes to flexmailer

### DIFF
--- a/src/Listener/DefaultSender.php
+++ b/src/Listener/DefaultSender.php
@@ -114,18 +114,9 @@ class DefaultSender extends BaseListener {
           \CRM_Core_Error::debug_log_message("Too many SMTP Socket Errors. Exiting");
           \CRM_Utils_System::civiExit();
         }
-
-        // Register the bounce event.
-
-        $params = array(
-          'event_queue_id' => $task->getEventQueueId(),
-          'job_id' => $job->id,
-          'hash' => $task->getHash(),
-        );
-        $params = array_merge($params,
-          \CRM_Mailing_BAO_BouncePattern::match($result->getMessage())
-        );
-        \CRM_Mailing_Event_BAO_Bounce::create($params);
+        else {
+          $this->recordBounce($job, $task, $result->getMessage());
+        }
       }
       else {
         // Register the delivery event.
@@ -217,6 +208,23 @@ class DefaultSender extends BaseListener {
     }
 
     return FALSE;
+  }
+
+  /**
+   * @param \CRM_Mailing_BAO_MailingJob $job
+   * @param FlexMailerTask $task
+   * @param string $errorMessage
+   */
+  protected function recordBounce($job, $task, $errorMessage) {
+    $params = array(
+      'event_queue_id' => $task->getEventQueueId(),
+      'job_id' => $job->id,
+      'hash' => $task->getHash(),
+    );
+    $params = array_merge($params,
+      \CRM_Mailing_BAO_BouncePattern::match($errorMessage)
+    );
+    \CRM_Mailing_Event_BAO_Bounce::create($params);
   }
 
 }

--- a/src/Listener/DefaultSender.php
+++ b/src/Listener/DefaultSender.php
@@ -93,17 +93,7 @@ class DefaultSender extends BaseListener {
         /** @var \PEAR_Error $result */
         // CRM-9191
         $message = $result->getMessage();
-        // SMTP response code is buried in the message.
-        $code = preg_match('/ \(code: (.+), response: /', $message, $matches) ? $matches[1] : '';
-        if (
-          strpos($message, 'Failed to write to socket') !== FALSE ||
-          ((
-            strpos($message, 'Failed to set sender') !== FALSE ||
-            strpos($message, 'Failed to add recipient') !== FALSE ||
-            strpos($message, 'Failed to send data') !== FALSE
-          // Register 5xx SMTP response code (permanent failure) as bounce.
-          ) && substr($code, 0, 1) !== '5')
-        ) {
+        if ($this->isTemporaryError($result->getMessage())) {
           // lets log this message and code
           $code = $result->getCode();
           \CRM_Core_Error::debug_log_message("SMTP Socket Error or failed to set sender error. Message: $message, Code: $code");
@@ -190,6 +180,43 @@ class DefaultSender extends BaseListener {
       $completed = FALSE;
     }
     $e->setCompleted($completed);
+  }
+
+  /**
+   * Determine if an SMTP error is temporary or permanent.
+   *
+   * @param string $message
+   *   PEAR error message.
+   * @return bool
+   *   TRUE - Temporary/retriable error
+   *   FALSE - Permanent/non-retriable error
+   */
+  protected function isTemporaryError($message) {
+    // SMTP response code is buried in the message.
+    $code = preg_match('/ \(code: (.+), response: /', $message, $matches) ? $matches[1] : '';
+
+    if (strpos($message, 'Failed to write to socket') !== FALSE) {
+      return TRUE;
+    }
+
+    // Register 5xx SMTP response code (permanent failure) as bounce.
+    if ($code{0} === '5') {
+      return FALSE;
+    }
+
+    if (strpos($message, 'Failed to set sender') !== FALSE) {
+      return TRUE;
+    }
+
+    if (strpos($message, 'Failed to add recipient') !== FALSE) {
+      return TRUE;
+    }
+
+    if (strpos($message, 'Failed to send data') !== FALSE) {
+      return TRUE;
+    }
+
+    return FALSE;
   }
 
 }

--- a/src/Listener/DefaultSender.php
+++ b/src/Listener/DefaultSender.php
@@ -82,8 +82,7 @@ class DefaultSender extends BaseListener {
       }
 
       $headers = $message->headers();
-      $result = $mailer->send($headers['To'], $message->headers(),
-        $message->get());
+      $result = $mailer->send($headers['To'], $message->headers(), $message->get());
 
       if ($job_date) {
         unset($errorScope);

--- a/src/Listener/DefaultSender.php
+++ b/src/Listener/DefaultSender.php
@@ -157,7 +157,7 @@ class DefaultSender extends BaseListener {
       // If we have enabled the Throttle option, this is the time to enforce it.
       $mailThrottleTime = \CRM_Core_Config::singleton()->mailThrottleTime;
       if (!empty($mailThrottleTime)) {
-        usleep((int ) $mailThrottleTime);
+        usleep((int) $mailThrottleTime);
       }
     }
 


### PR DESCRIPTION
After an SMTP socket error or temporary failure, we should 1) disconnect the SMTP connection so it can reconnect on the next attempt and 2) consider the batch not completed so it can be completed by a later job.

The logic here will consider a 5xx error to be a permanent failure, and not retry the message.

This PR should be kept in sync with https://github.com/civicrm/civicrm-core/pull/11838 and https://github.com/civicrm/civicrm-core/pull/11840 (I broke it into two PRs for CiviCRM core since sometimes small PRs are easier to test...)

Some sample real-world SMTP temporary failures this will allow to be retried:

`Failed to set sender: b.***@***.example.org [SMTP: Invalid response code received from SMTP server while sending email.  This is often caused by a misconfiguration in Outbound Email settings. Please verify the settings at Administer CiviCRM >> Global Settings >> Outbound Email (SMTP). (code: 421, response: Timeout waiting for data from client.)]`

`Failed to send data [SMTP: Invalid response code received from SMTP server while sending email.  This is often caused by a misconfiguration in Outbound Email settings. Please verify the settings at Administer CiviCRM >> Global Settings >> Outbound Email (SMTP). (code: 454, response: Throttling failure: Maximum sending rate exceeded.)]`

See also:
 * [PR #11838 - CiviMail: Fix support for SMTP delivery to AWS SES](https://github.com/civicrm/civicrm-core/pull/11838)
 * [PR #11840 - CiviMail: If SMTP connection error is detected, disconnect so we can reconnect and retry](https://github.com/civicrm/civicrm-core/pull/11840)