### PR TITLE
autogenerate the plain text version after token substitution

### DIFF
--- a/src/Listener/DefaultComposer.php
+++ b/src/Listener/DefaultComposer.php
@@ -41,7 +41,7 @@ use Civi\Token\TokenRow;
  */
 class DefaultComposer extends BaseListener {
 
-  protected $autoGeneratePlainText = false;
+  protected $autoGeneratePlainText = FALSE;
 
   public function onRun(RunEvent $e) {
     // FIXME: This probably doesn't belong here...
@@ -76,13 +76,12 @@ class DefaultComposer extends BaseListener {
 
     $tpls = $this->createMessageTemplates($e);
     $tp->addMessage('subject', $tpls['subject'], 'text/plain');
-    if(isset($tpls['html'])){
-      $tp->addMessage('body_html', isset($tpls['html']) ? $tpls['html'] : '', 'text/html');
-    }
-    if(isset($tpls['text'])){
-      $tp->addMessage('body_text', isset($tpls['text']) ? $tpls['text'] : '', 'text/plain');
-    }else{
-      $this->autoGeneratePlainText = true;
+    $tp->addMessage('body_text', isset($tpls['text']) ? $tpls['text'] : '',
+      'text/plain');
+    $tp->addMessage('body_html', isset($tpls['html']) ? $tpls['html'] : '',
+      'text/html');
+    if (empty($tpls['text'])) {
+      $this->autoGeneratePlainText = TRUE;
     }
 
     $hasContent = FALSE;
@@ -166,13 +165,15 @@ class DefaultComposer extends BaseListener {
     FlexMailerTask $task,
     TokenRow $row
   ) {
-    $params['Subject'] = $row->render('subject');
-    $params['html'] = $row->render('body_html');
-    $params['text'] = $row->render('body_text');
-    if($this->autoGeneratePlainText){
-      $params['text'] = \CRM_Utils_String::htmlToText($params['html']);
-    }else{}
-    return $params;
+    $html = $row->render('body_html');
+    $text = $this->autoGeneratePlainText ?
+      \CRM_Utils_String::htmlToText($html) :
+      $row->render('body_text');
+    return array(
+      'Subject' => $row->render('subject'),
+      'text' => $text,
+      'html' => $html,
+    );
   }
 
   /**
@@ -234,4 +235,5 @@ class DefaultComposer extends BaseListener {
     // of garbage data.
     return $e->getMailing()->url_tracking && !$e->isPreview();
   }
+
 }


### PR DESCRIPTION
This PR alters `DefaultComposer` as follows:

Only create a body_text (text/plain)` message for TokenProcessor if body_text has been specified. If it has not bee specified, set `$autoGeneratePlainText` to true for DefaultComposer so we know to auto generate the plain text version later on

Once any token substitution and link tracking has happened, if no plain text version has been specified, run the generated HTML through `CRM_Utils_String::htmlToText` to create a plain text version of the email.

See associated PR on civicrm-core for more details.