### PR TITLE
Call mailing.preview api on view mailing page

### DIFF
--- a/flexmailer.php
+++ b/flexmailer.php
@@ -191,6 +191,15 @@ function flexmailer_civicrm_navigationMenu(&$menu) {
 } // */
 
 /**
+ * Implements hook_civicrm_alterMenu().
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_alterMenu
+ */
+function flexmailer_civicrm_alterMenu(&$items) {
+  $items['civicrm/mailing/view']['page_callback'] = '\Civi\FlexMailer\Page\ViewMailing';
+}
+
+/**
  * Implements hook_civicrm_container().
  */
 function flexmailer_civicrm_container($container) {

--- a/src/Page/ViewMailing.php
+++ b/src/Page/ViewMailing.php
@@ -1,0 +1,64 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2017                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+namespace Civi\FlexMailer\Page;
+
+/**
+ * Class ViewMailing
+ * @package Civi\FlexMailer\Page
+ */
+class ViewMailing {
+
+  /**
+   * Call mailing.preview api when the mailing is viewed.
+   *
+   * @return null
+   */
+  public function run() {
+    $mailingID = \CRM_Utils_Request::retrieve('id', 'Int', \CRM_Core_DAO::$_nullObject, TRUE);
+    $result = civicrm_api3('Mailing', 'preview', [
+      'id' => $mailingID,
+    ]);
+    $mailing = \CRM_Utils_Array::value('values', $result);
+    if (isset($mailing['body_html']) && empty($_GET['text'])) {
+      $header = 'text/html; charset=utf-8';
+      $content = $mailing['body_html'];
+    }
+    else {
+      $header = 'text/plain; charset=utf-8';
+      $content = $mailing['body_text'];
+    }
+    \CRM_Utils_System::setTitle($mailing['subject']);
+    if (\CRM_Utils_Array::value('snippet', $_GET) === 'json') {
+      \CRM_Core_Page_AJAX::returnJsonResponse($content);
+    }
+    \CRM_Utils_System::setHttpHeader('Content-Type', $header);
+
+    print $content;
+    \CRM_Utils_System::civiExit();
+  }
+
+}


### PR DESCRIPTION
Override `civicrm/mailing/view` link to call mailing.preview api and render its content.

Discussion https://github.com/veda-consulting/uk.co.vedaconsulting.mosaico/pull/252