### PR TITLE
the SMTP response code could be empty string

### DIFF
--- a/src/Listener/DefaultSender.php
+++ b/src/Listener/DefaultSender.php
@@ -190,7 +190,7 @@ class DefaultSender extends BaseListener {
     }
 
     // Register 5xx SMTP response code (permanent failure) as bounce.
-    if ($code{0} === '5') {
+    if (isset($code{0}) && $code{0} === '5') {
       return FALSE;
     }
 


### PR DESCRIPTION
Minor fixup for previous commit - the SMTP response code could be empty string, and thus $code{0} would not exist.