### PR TITLE
(mosaico#247) (dev/core#588) Apply prefix to subject of test mailings

### DIFF
--- a/docs/develop/index.md
+++ b/docs/develop/index.md
@@ -126,6 +126,7 @@ For more detailed information about how to manipulate a service, consult its doc
      * `civi_flexmailer_default_composer` (`DefaultComposer.php`): Read the email template and evaluate any tokens (based on CiviMail tokens)
      * `civi_flexmailer_attachments` (`Attachments.php`): Add attachments
      * `civi_flexmailer_open_tracker` (`OpenTracker.php`): Add open-tracking codes
+     * `civi_flexmailer_test_prefix` (`TestPrefix.php`): Add a prefix to any test mailings
      * `civi_flexmailer_hooks` (`HookAdapter.php`): Backward compatibility with `hook_civicrm_alterMailParams`
 * Listener services (`SendBatchEvent`)
      * `civi_flexmailer_default_sender` (`DefaultSender.php`): Send the batch using CiviCRM's default delivery service

--- a/src/Listener/TestPrefix.php
+++ b/src/Listener/TestPrefix.php
@@ -1,0 +1,52 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2017                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+namespace Civi\FlexMailer\Listener;
+
+use Civi\FlexMailer\Event\ComposeBatchEvent;
+use Civi\FlexMailer\FlexMailerTask;
+
+class TestPrefix extends BaseListener {
+
+  /**
+   * For any test mailings, the "Subject:" should have a prefix.
+   *
+   * @param \Civi\FlexMailer\Event\ComposeBatchEvent $e
+   */
+  public function onCompose(ComposeBatchEvent $e) {
+    if (!$this->isActive() || !$e->getJob()->is_test) {
+      return;
+    }
+
+    foreach ($e->getTasks() as $task) {
+      /** @var FlexMailerTask $task */
+      $subject = $task->getMailParam('Subject');
+      $subject = ts('[CiviMail Draft]') . ' ' . $subject;
+      $task->setMailParam('Subject', $subject);
+    }
+  }
+
+}

--- a/src/Services.php
+++ b/src/Services.php
@@ -80,6 +80,7 @@ class Services {
     $container->setDefinition('civi_flexmailer_bounce_tracker', new Definition('Civi\FlexMailer\Listener\BounceTracker'));
     $container->setDefinition('civi_flexmailer_default_sender', new Definition('Civi\FlexMailer\Listener\DefaultSender'));
     $container->setDefinition('civi_flexmailer_hooks', new Definition('Civi\FlexMailer\Listener\HookAdapter'));
+    $container->setDefinition('civi_flexmailer_test_prefix', new Definition('Civi\FlexMailer\Listener\TestPrefix'));
 
     $container->setDefinition('civi_flexmailer_html_click_tracker', new Definition('Civi\FlexMailer\ClickTracker\HtmlClickTracker'));
     $container->setDefinition('civi_flexmailer_text_click_tracker', new Definition('Civi\FlexMailer\ClickTracker\TextClickTracker'));
@@ -126,6 +127,7 @@ class Services {
     $listenerSpecs[] = array(FM::EVENT_COMPOSE, array('civi_flexmailer_default_composer', 'onCompose'), FM::WEIGHT_MAIN - 100);
     $listenerSpecs[] = array(FM::EVENT_COMPOSE, array('civi_flexmailer_attachments', 'onCompose'), FM::WEIGHT_ALTER);
     $listenerSpecs[] = array(FM::EVENT_COMPOSE, array('civi_flexmailer_open_tracker', 'onCompose'), FM::WEIGHT_ALTER);
+    $listenerSpecs[] = array(FM::EVENT_COMPOSE, array('civi_flexmailer_test_prefix', 'onCompose'), FM::WEIGHT_ALTER);
     $listenerSpecs[] = array(FM::EVENT_COMPOSE, array('civi_flexmailer_hooks', 'onCompose'), FM::WEIGHT_ALTER - 100);
 
     $listenerSpecs[] = array(FM::EVENT_SEND, array('civi_flexmailer_default_sender', 'onSend'), FM::WEIGHT_END);

--- a/tests/phpunit/Civi/FlexMailer/MailingPreviewTest.php
+++ b/tests/phpunit/Civi/FlexMailer/MailingPreviewTest.php
@@ -93,7 +93,7 @@ class MailingPreviewTest extends \CiviUnitTestCase {
       'SELECT MAX(id) FROM civicrm_mailing_recipients'); // 'Preview should not create any mailing_recipient records'
 
     $previewResult = $result['values'][$result['id']]['api.Mailing.preview'];
-    $this->assertEquals("Hello $displayName",
+    $this->assertEquals("[CiviMail Draft] Hello $displayName",
       $previewResult['values']['subject']);
     $this->assertContains("This is $displayName",
       $previewResult['values']['body_text']);


### PR DESCRIPTION
This is was previously fixed in https://github.com/civicrm/civicrm-core/pull/12758, but that fix had a
couple undesired side-effect:

* For non-Mosaico mailings, the prefix would be applied twice (https://lab.civicrm.org/dev/core/issues/588);
  once in the JS layer and once in the BAO delivery engine.
* The saved value of the `subject` would temporarily store the prefix as part of the subject.
  (In normal usage, it would be fixed later by an autosave; but there could be edge-cases/races.)

This is an alternative fix which makes flexmailer more precisely imitate the
behavior in the BAO delivery engine.

Note: If one doesn't like this behavior, then you can disable or replace the service, e.g.

```php
Civi::service('civi_flexmailer_test_prefix')->setActive(FALSE);
```