### PR TITLE
Fix loading of mailing view page for anonymous users

### DIFF
--- a/src/Listener/ToHeader.php
+++ b/src/Listener/ToHeader.php
@@ -71,7 +71,7 @@ class ToHeader extends BaseListener {
     }
 
     $ids = array_filter($ids, 'is_numeric');
-    if (!$ids) {
+    if (empty($ids)) {
       return array();
     }
 

--- a/src/Listener/ToHeader.php
+++ b/src/Listener/ToHeader.php
@@ -70,11 +70,12 @@ class ToHeader extends BaseListener {
       $ids[$task->getContactId()] = $task->getContactId();
     }
 
+    $ids = array_filter($ids, 'is_numeric');
     if (!$ids) {
       return array();
     }
 
-    $idString = implode(',', array_filter($ids, 'is_numeric'));
+    $idString = implode(',', $ids);
 
     $query = \CRM_Core_DAO::executeQuery(
       "SELECT id, display_name FROM civicrm_contact WHERE id in ($idString)");


### PR DESCRIPTION
Fixes https://github.com/civicrm/org.civicrm.flexmailer/issues/29

Mailing view page now uses flexmailing preview API to view the mailing which displays a DB error for anonymous users.

The function `getContactNames()` seems to return an empty array if it does not find any contact in the `$ids` variable. 

The condition `if (!$ids) {` does not seem to work if `$task->getContactId()` returns an empty string. Moved the `array_filter` just above the check and it works fine now.