### PR TITLE
Fixed view mailing for anonymous users.

### DIFF
--- a/src/Page/ViewMailing.php
+++ b/src/Page/ViewMailing.php
@@ -39,23 +39,8 @@ class ViewMailing {
    */
   public function run() {
     $mailingID = \CRM_Utils_Request::retrieve('id', 'Int', \CRM_Core_DAO::$_nullObject, TRUE);
-    $result = civicrm_api3('Mailing', 'preview', [
-      'id' => $mailingID,
-    ]);
-    $mailing = \CRM_Utils_Array::value('values', $result);
-    if (isset($mailing['body_html']) && empty($_GET['text'])) {
-      $header = 'text/html; charset=utf-8';
-      $content = $mailing['body_html'];
-    }
-    else {
-      $header = 'text/plain; charset=utf-8';
-      $content = $mailing['body_text'];
-    }
-    \CRM_Utils_System::setTitle($mailing['subject']);
-    if (\CRM_Utils_Array::value('snippet', $_GET) === 'json') {
-      \CRM_Core_Page_AJAX::returnJsonResponse($content);
-    }
-    \CRM_Utils_System::setHttpHeader('Content-Type', $header);
+    $mailingView = new \CRM_Mailing_Page_View();
+    $content = $mailingView->run($mailingID);
 
     print $content;
     \CRM_Utils_System::civiExit();


### PR DESCRIPTION
When anonymous users try to view the email in a browser they get a database error, even if view public mail content permissions are set.

Discussion of the issue : https://github.com/civicrm/org.civicrm.flexmailer/issues/29

The following error is thrown,
```
CiviCRM_API3_Exception: "A fatal error was triggered: One of parameters (value: ) is not of the type Positive"
at
org.civicrm.flexmailer/src/Page/ViewMailing.php(43): civicrm_api3("Mailing", "preview", (Array:2))
```

To fix it, We've removed Mailing.preview API from ViewMailing->run() function and replaced the same with CRM_Mailing_Page_View() wrapper.