### PR TITLE
Mark 1.0 stable release

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,9 @@
     <url desc="Support">http://civicrm.stackexchange.com/</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2019-05-01</releaseDate>
-  <version>1.0-beta2</version>
+  <releaseDate>2019-05-30</releaseDate>
+  <version>1.0</version>
+  <develStage>stable</develStage>
   <comments>
     FlexMailer is an email delivery engine which replaces the internal guts
     of CiviMail.  It is a drop-in replacement which enables *other* extensions


### PR DESCRIPTION
Flexmailer has been marked as beta1 since December 2018 and no problems have reported.  We need a stable release now Mosaico is "stable" 2.0.