### PR TITLE
Add proper setting for toggling Flexmailer on traditional mailings 

### DIFF
--- a/CRM/Flexmailer/Form/FlexmailerAdmin.php
+++ b/CRM/Flexmailer/Form/FlexmailerAdmin.php
@@ -1,0 +1,23 @@
+<?php
+
+// use CRM_Flexmailer_ExtensionUtil as E;
+
+/**
+ * Form controller class
+ *
+ * @see https://wiki.civicrm.org/confluence/display/CRMDOC/QuickForm+Reference
+ */
+class CRM_Flexmailer_Form_FlexmailerAdmin extends CRM_Admin_Form_Setting {
+
+  protected $_settings = array(
+    'flexmailer_traditional' => 'Flexmailer Preferences',
+  );
+
+  /**
+   * Build the form object.
+   */
+  public function buildQuickForm() {
+    parent::buildQuickForm();
+  }
+
+}

--- a/flexmailer.php
+++ b/flexmailer.php
@@ -14,6 +14,8 @@ define('CIVICRM_FLEXMAILER_HACK_REQUIRED_TOKENS', 'call://civi_flexmailer_requir
 
 require_once 'flexmailer.civix.php';
 
+use CRM_Flexmailer_ExtensionUtil as E;
+
 /**
  * Define an autoloader for FlexMailer.
  *
@@ -196,4 +198,18 @@ function flexmailer_civicrm_container($container) {
     $container->addResource(new \Symfony\Component\Config\Resource\FileResource(__FILE__));
   }
   \Civi\FlexMailer\Services::registerServices($container);
+}
+
+/**
+ * Get a list of delivery options for traditional mailings.
+ *
+ * @return array
+ *   Array (string $machineName => string $label).
+ */
+function _flexmailer_traditional_options() {
+  return array(
+    'auto' => E::ts('Automatic'),
+    'bao' => E::ts('CiviMail BAO'),
+    'flexmailer' => E::ts('Flexmailer Pipeline'),
+  );
 }

--- a/flexmailer.php
+++ b/flexmailer.php
@@ -168,18 +168,19 @@ function flexmailer_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
  * Implements hook_civicrm_navigationMenu().
  *
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_navigationMenu
- *
+ */
 function flexmailer_civicrm_navigationMenu(&$menu) {
-  _flexmailer_civix_insert_navigation_menu($menu, NULL, array(
-    'label' => ts('The Page', array('domain' => 'org.civicrm.flexmailer')),
-    'name' => 'the_page',
-    'url' => 'civicrm/the-page',
-    'permission' => 'access CiviReport,access CiviContribute',
-    'operator' => 'OR',
+  _flexmailer_civix_insert_navigation_menu($menu, 'Administer/CiviMail', [
+    'label' => ts('Flexmailer Settings', array('domain' => 'org.civicrm.flexmailer')),
+    'name' => 'flexmailer_settings',
+    'permission' => 'administer CiviCRM',
+    'child' => array(),
+    'operator' => 'AND',
     'separator' => 0,
-  ));
+    'url' => CRM_Utils_System::url('civicrm/admin/flexmailer', 'reset=1', TRUE),
+  ]);
   _flexmailer_civix_navigationMenu($menu);
-} // */
+}
 
 /**
  * Implements hook_civicrm_alterMenu().

--- a/settings/Flexmailer.setting.php
+++ b/settings/Flexmailer.setting.php
@@ -1,0 +1,20 @@
+<?php
+return [
+  'flexmailer_traditional' => [
+    'group_name' => 'Flexmailer Preferences',
+    'group' => 'flexmailer',
+    'name' => 'flexmailer_layout',
+    'quick_form_type' => 'Select',
+    'type' => 'String',
+    'html_type' => 'select',
+    'html_attributes' => ['class' => 'crm-select2'],
+    'pseudoconstant' => ['callback' => '_flexmailer_traditional_options'],
+    'default' => 'auto',
+    'add' => '5.13',
+    'title' => 'Traditional Mailing Handler',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => NULL,
+    'help_text' => NULL,
+  ],
+];

--- a/templates/CRM/Flexmailer/Form/FlexmailerAdmin.tpl
+++ b/templates/CRM/Flexmailer/Form/FlexmailerAdmin.tpl
@@ -1,0 +1,20 @@
+{crmScope extensionKey='org.civicrm.flexmailer'}
+  <div class="crm-block crm-form-block crm-flexmailer-form-block">
+    {*<div class="help">*}
+    {*{ts}...{/ts} {docURL page="Debugging for developers" resource="wiki"}*}
+    {*</div>*}
+    <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
+    <table class="form-layout">
+      <tr class="crm-flexmailer-form-block-flexmailer_traditional">
+        <td class="label">{$form.flexmailer_traditional.label}</td>
+        <td>{$form.flexmailer_traditional.html}<br />
+          <span class="description">
+            {ts}For greater backward-compatibility, process "<code>traditional</code>" mailings with the CiviMail's hard-coded BAO.{/ts}<br/>
+            {ts}For greater forward-compatibility, process "<code>traditional</code>" mailings with Flexmailer's extensible pipeline.{/ts}<br/>
+          </span>
+        </td>
+      </tr>
+    </table>
+    <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
+  </div>
+{/crmScope}

--- a/tests/phpunit/Civi/FlexMailer/ConcurrentDeliveryTest.php
+++ b/tests/phpunit/Civi/FlexMailer/ConcurrentDeliveryTest.php
@@ -58,14 +58,14 @@ class ConcurrentDeliveryTest extends \api_v3_JobProcessMailingTest {
 
     parent::setUp();
 
-    \CRM_Core_BAO_Setting::setItem(TRUE, 'Mailing Preferences', 'experimentalFlexMailerEngine');
+    \Civi::settings()->set('flexmailer_traditional', 'flexmailer');
   }
 
   public function tearDown() {
     // We're building on someone else's test and don't fully trust them to
     // protect our settings. Make sure they did.
-    $ok = (TRUE == \CRM_Core_BAO_Setting::getItem('Mailing Preferences', 'experimentalFlexMailerEngine'))
-      && ('b:1;' === \CRM_Core_DAO::singleValueQuery('SELECT value FROM civicrm_setting WHERE name ="experimentalFlexMailerEngine"'));
+    $ok = ('flexmailer' == \Civi::settings()->get('flexmailer_traditional'))
+      && ('s:10:"flexmailer";' === \CRM_Core_DAO::singleValueQuery('SELECT value FROM civicrm_setting WHERE name ="flexmailer_traditional"'));
 
     parent::tearDown();
 

--- a/tests/phpunit/Civi/FlexMailer/FlexMailerSystemTest.php
+++ b/tests/phpunit/Civi/FlexMailer/FlexMailerSystemTest.php
@@ -63,7 +63,7 @@ class FlexMailerSystemTest extends \CRM_Mailing_BaseMailingSystemTest {
     }
 
     parent::setUp();
-    \CRM_Core_BAO_Setting::setItem(TRUE, 'Mailing Preferences', 'experimentalFlexMailerEngine');
+    \Civi::settings()->set('flexmailer_traditional', 'flexmailer');
 
     $dispatcher = \Civi::service('dispatcher');
     foreach (FlexMailer::getEventTypes() as $event => $class) {

--- a/tests/phpunit/Civi/FlexMailer/MailingPreviewTest.php
+++ b/tests/phpunit/Civi/FlexMailer/MailingPreviewTest.php
@@ -30,7 +30,7 @@ class MailingPreviewTest extends \CiviUnitTestCase {
 
     parent::setUp();
 
-    \CRM_Core_BAO_Setting::setItem(TRUE, 'Mailing Preferences', 'experimentalFlexMailerEngine');
+    \Civi::settings()->set('flexmailer_traditional', 'flexmailer');
 
     $this->useTransaction();
     \CRM_Mailing_BAO_MailingJob::$mailsProcessed = 0; // DGW

--- a/tests/phpunit/Civi/FlexMailer/ValidatorTest.php
+++ b/tests/phpunit/Civi/FlexMailer/ValidatorTest.php
@@ -44,7 +44,7 @@ class ValidatorTest extends \CiviUnitTestCase {
     }
 
     parent::setUp();
-    \CRM_Core_BAO_Setting::setItem(TRUE, 'Mailing Preferences', 'experimentalFlexMailerEngine');
+    \Civi::settings()->set('flexmailer_traditional', 'flexmailer');
   }
 
   public function getExamples() {

--- a/xml/Menu/flexmailer.xml
+++ b/xml/Menu/flexmailer.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<menu>
+  <item>
+    <path>civicrm/admin/flexmailer</path>
+    <page_callback>CRM_Flexmailer_Form_FlexmailerAdmin</page_callback>
+    <title>Flexmailer Settings</title>
+    <adminGroup>CiviMail</adminGroup>
+    <icon>admin/small/Profile.png</icon>
+    <access_arguments>administer CiviCRM</access_arguments>
+  </item>
+</menu>


### PR DESCRIPTION
Before
-------

When you enable Flexmailer, it is used for new-style mailings (e.g. Mosaico). However, it is not used to deliver `traditional` mailings.

There is a hidden/undocumented setting (`experimentalFlexMailerEngine`) to toggle this. The setting has primarily been used for automated testing, but it has also been communicated to other developers/implementers.

After
------

* There is a setting `flexmailer_traditional` which dictates whether Flexmailer will try to process `traditional` mailings.
* The setting is exposed in a new admin form.
* The old hidden setting `experimentalFlexMailerEngine` is mostly removed. However, if you have `flexmailer_traditional=auto`, it will fallback and obey `experimentalFlexMailerEngine`.

Comments
------

The automated tests rely on some forms of this setting to work correctly.

Additionally, to make sure that every form was tried in a realistic way, I used these manual steps:

* Setup a test site. Enable Flexmailer with this patch. Configure outbound mail to go an SMTP simulator (eg `mailcatcher`).
* Locally, hack `Civi\FlexMailer\Listener\BasicHeaders` to set `$mailParams['X-Flexmailer'] = 'Yes';`. This way, you can determine which engine sent a message by inspecting the headers.
* Prepare a draft mailing.
* Check: Does CiviMail's test/preview functionality work?
    * Repeat this procedure for each value of `flexmailer_traditional` (`auto`, `bao`, `flexmailer`):
        * Set `flexmailer_traditional` to the desired value
        * Preview as text
        * Preview as HTML
        * Send test email to one address
        * Send test email a group
* Submit the test mailing. Save a DB snapshot (e.g. `civibuild snapshot dmaster --snapshot dm-send`)
* Check: Does delivery work?
    * Repeat this procedure for each value of `flexmailer_traditional` (`auto`, `bao`, `flexmailer`):
        * Restore DB
        * Set `flexmailer_traditional` to the desired value
        * Run the delivery
        * Check the resulting messages
        * (Ex: `civibuild restore dmaster --snapshot dm-send && cv flush && cv api setting.create flexmailer_traditional=THE_VALUE && cv api -U admin job.process_mailing`)

To work completely, depends on #38. However, that's a preexisting issue, and it mostly works without.