### PR TITLE
(dev/mail#20) Mailing.preview - Fix regression circa Civi 5.6.x

### DIFF
--- a/src/Listener/DefaultComposer.php
+++ b/src/Listener/DefaultComposer.php
@@ -116,6 +116,7 @@ class DefaultComposer extends BaseListener {
       'controller' => get_class($this),
       // FIXME: Use template_type, template_options
       'smarty' => defined('CIVICRM_MAIL_SMARTY') && CIVICRM_MAIL_SMARTY ? TRUE : FALSE,
+      'mailing' => $e->getMailing(),
       'mailingId' => $e->getMailing()->id,
     );
     // REMOVE ME: This is a short-term compatibility adjustment.

--- a/tests/phpunit/Civi/FlexMailer/MailingPreviewTest.php
+++ b/tests/phpunit/Civi/FlexMailer/MailingPreviewTest.php
@@ -39,8 +39,8 @@ class MailingPreviewTest extends \CiviUnitTestCase {
     $this->_email = 'test@test.test';
     $this->_params = array(
       'subject' => 'Hello {contact.display_name}',
-      'body_text' => "This is {contact.display_name}.\nhttps://civicrm.org\n{domain.address}{action.optOutUrl}",
-      'body_html' => "<p>This is {contact.display_name}.</p><p><a href='https://civicrm.org/'>CiviCRM.org</a></p><p>{domain.address}{action.optOutUrl}</p>",
+      'body_text' => "This is {contact.display_name}.\nhttps://civicrm.org\nda=({domain.address}) optout=({action.optOutUrl})",
+      'body_html' => "<p>This is {contact.display_name}.</p><p><a href='https://civicrm.org/'>CiviCRM.org</a></p><p>da=({domain.address}) optout=({action.optOutUrl})</p>",
       'name' => 'mailing name',
       'created_id' => $this->_contactID,
       'header_id' => '',
@@ -76,30 +76,75 @@ class MailingPreviewTest extends \CiviUnitTestCase {
     $params['options']['force_rollback'] = 1;
     // END SAMPLE DATA
 
-    $maxIDs = array(
-      'mailing' => \CRM_Core_DAO::singleValueQuery('SELECT MAX(id) FROM civicrm_mailing'),
-      'job' => \CRM_Core_DAO::singleValueQuery('SELECT MAX(id) FROM civicrm_mailing_job'),
-      'group' => \CRM_Core_DAO::singleValueQuery('SELECT MAX(id) FROM civicrm_mailing_group'),
-      'recipient' => \CRM_Core_DAO::singleValueQuery('SELECT MAX(id) FROM civicrm_mailing_recipients'),
-    );
+    $maxIDs = $this->getMaxIds();
     $result = $this->callAPISuccess('mailing', 'create', $params);
-    $this->assertDBQuery($maxIDs['mailing'],
-      'SELECT MAX(id) FROM civicrm_mailing'); // 'Preview should not create any mailing records'
-    $this->assertDBQuery($maxIDs['job'],
-      'SELECT MAX(id) FROM civicrm_mailing_job'); // 'Preview should not create any mailing_job record'
-    $this->assertDBQuery($maxIDs['group'],
-      'SELECT MAX(id) FROM civicrm_mailing_group'); // 'Preview should not create any mailing_group records'
-    $this->assertDBQuery($maxIDs['recipient'],
-      'SELECT MAX(id) FROM civicrm_mailing_recipients'); // 'Preview should not create any mailing_recipient records'
+    $this->assertMaxIds($maxIDs);
 
     $previewResult = $result['values'][$result['id']]['api.Mailing.preview'];
     $this->assertEquals("[CiviMail Draft] Hello $displayName",
       $previewResult['values']['subject']);
-    $this->assertContains("This is $displayName",
-      $previewResult['values']['body_text']);
-    $this->assertContains("<p>This is $displayName.</p>",
-      $previewResult['values']['body_html']);
+
+    $this->assertContains("This is $displayName", $previewResult['values']['body_text']);
+    $this->assertContains("civicrm/mailing/optout", $previewResult['values']['body_text']);
+    $this->assertContains("&jid=&qid=&h=fakehash", $previewResult['values']['body_text']);
+
+    $this->assertContains("<p>This is $displayName.</p>", $previewResult['values']['body_html']);
+    $this->assertContains("civicrm/mailing/optout", $previewResult['values']['body_html']);
+    $this->assertContains("&amp;jid=&amp;qid=&amp;h=fakehash", $previewResult['values']['body_html']);
+
     $this->assertEquals('flexmailer', $previewResult['values']['_rendered_by_']);
+  }
+
+  public function testMailerPreviewWithoutId() {
+    // BEGIN SAMPLE DATA
+    $contactID = $this->createLoggedInUser();
+    $displayName = $this->callAPISuccess('contact', 'get', ['id' => $contactID]);
+    $displayName = $displayName['values'][$contactID]['display_name'];
+    $this->assertTrue(!empty($displayName));
+    $params = $this->_params;
+    // END SAMPLE DATA
+
+    $maxIDs = $this->getMaxIds();
+    $previewResult = $this->callAPISuccess('mailing', 'preview', $params);
+    $this->assertMaxIds($maxIDs);
+
+    $this->assertEquals("[CiviMail Draft] Hello $displayName",
+      $previewResult['values']['subject']);
+
+    $this->assertContains("This is $displayName", $previewResult['values']['body_text']);
+    $this->assertContains("civicrm/mailing/optout", $previewResult['values']['body_text']);
+    $this->assertContains("&jid=&qid=&h=fakehash", $previewResult['values']['body_text']);
+
+    $this->assertContains("<p>This is $displayName.</p>", $previewResult['values']['body_html']);
+    $this->assertContains("civicrm/mailing/optout", $previewResult['values']['body_html']);
+    $this->assertContains("&amp;jid=&amp;qid=&amp;h=fakehash", $previewResult['values']['body_html']);
+
+    $this->assertEquals('flexmailer', $previewResult['values']['_rendered_by_']);
+  }
+
+  /**
+   * @return array
+   *   Array(string $table => int $maxID).
+   */
+  protected function getMaxIds() {
+    return array(
+      'civicrm_mailing' => \CRM_Core_DAO::singleValueQuery('SELECT MAX(id) FROM civicrm_mailing'),
+      'civicrm_mailing_job' => \CRM_Core_DAO::singleValueQuery('SELECT MAX(id) FROM civicrm_mailing_job'),
+      'civicrm_mailing_group' => \CRM_Core_DAO::singleValueQuery('SELECT MAX(id) FROM civicrm_mailing_group'),
+      'civicrm_mailing_recipients' => \CRM_Core_DAO::singleValueQuery('SELECT MAX(id) FROM civicrm_mailing_recipients'),
+    );
+  }
+
+  /**
+   * Assert that the given tables have the given extant IDs.
+   *
+   * @param array $expectMaxIds
+   *   Array(string $table => int $maxId).
+   */
+  protected function assertMaxIds($expectMaxIds) {
+    foreach ($expectMaxIds as $table => $maxId) {
+      $this->assertDBQuery($expectMaxIds[$table], 'SELECT MAX(id) FROM ' . $table, [], "Table $table should have a maximum ID of $maxId");
+    }
   }
 
 }

--- a/tests/phpunit/Civi/FlexMailer/MailingPreviewTest.php
+++ b/tests/phpunit/Civi/FlexMailer/MailingPreviewTest.php
@@ -39,8 +39,8 @@ class MailingPreviewTest extends \CiviUnitTestCase {
     $this->_email = 'test@test.test';
     $this->_params = array(
       'subject' => 'Hello {contact.display_name}',
-      'body_text' => "This is {contact.display_name}.\nhttps://civicrm.org\nda=({domain.address}) optout=({action.optOutUrl})",
-      'body_html' => "<p>This is {contact.display_name}.</p><p><a href='https://civicrm.org/'>CiviCRM.org</a></p><p>da=({domain.address}) optout=({action.optOutUrl})</p>",
+      'body_text' => "This is {contact.display_name}.\nhttps://civicrm.org\nda=({domain.address}) optout=({action.optOutUrl}) subj=({mailing.subject})",
+      'body_html' => "<p>This is {contact.display_name}.</p><p><a href='https://civicrm.org/'>CiviCRM.org</a></p><p>da=({domain.address}) optout=({action.optOutUrl}) subj=({mailing.subject})</p>",
       'name' => 'mailing name',
       'created_id' => $this->_contactID,
       'header_id' => '',
@@ -87,10 +87,12 @@ class MailingPreviewTest extends \CiviUnitTestCase {
     $this->assertContains("This is $displayName", $previewResult['values']['body_text']);
     $this->assertContains("civicrm/mailing/optout", $previewResult['values']['body_text']);
     $this->assertContains("&jid=&qid=&h=fakehash", $previewResult['values']['body_text']);
+    $this->assertContains("subj=(Hello ", $previewResult['values']['body_text']);
 
     $this->assertContains("<p>This is $displayName.</p>", $previewResult['values']['body_html']);
     $this->assertContains("civicrm/mailing/optout", $previewResult['values']['body_html']);
     $this->assertContains("&amp;jid=&amp;qid=&amp;h=fakehash", $previewResult['values']['body_html']);
+    $this->assertContains("subj=(Hello ", $previewResult['values']['body_html']);
 
     $this->assertEquals('flexmailer', $previewResult['values']['_rendered_by_']);
   }
@@ -114,10 +116,12 @@ class MailingPreviewTest extends \CiviUnitTestCase {
     $this->assertContains("This is $displayName", $previewResult['values']['body_text']);
     $this->assertContains("civicrm/mailing/optout", $previewResult['values']['body_text']);
     $this->assertContains("&jid=&qid=&h=fakehash", $previewResult['values']['body_text']);
+    $this->assertContains("subj=(Hello ", $previewResult['values']['body_text']);
 
     $this->assertContains("<p>This is $displayName.</p>", $previewResult['values']['body_html']);
     $this->assertContains("civicrm/mailing/optout", $previewResult['values']['body_html']);
     $this->assertContains("&amp;jid=&amp;qid=&amp;h=fakehash", $previewResult['values']['body_html']);
+    $this->assertContains("subj=(Hello ", $previewResult['values']['body_html']);
 
     $this->assertEquals('flexmailer', $previewResult['values']['_rendered_by_']);
   }


### PR DESCRIPTION
Flexmailer overrides the `Mailing.preview` API.  In
https://github.com/civicrm/civicrm-core/pull/12509 (5.6), it became possible
to call `Mailing.preview` without an `id` for the mailing.

This update Flexmailer `Mailing.preview` to also work without an ID.

It resolves a symptom in which clicking "Preview as (HTML/Text)" seems to work - but renders `mailing#1` instead of rendering the actual draft mailing.