### PR TITLE
Construct tracking URL with an alternate method to avoid language prefix be appended to base URL

### DIFF
--- a/src/Listener/OpenTracker.php
+++ b/src/Listener/OpenTracker.php
@@ -47,8 +47,13 @@ class OpenTracker extends BaseListener {
       $mailParams = $task->getMailParams();
 
       if (!empty($mailParams) && !empty($mailParams['html'])) {
+        $tracking_url = $config->userSystem->languageNegotiationURL(
+          $config->userFrameworkBaseURL . \Civi::settings()->get('userFrameworkResourceURL') . "/extern/open.php?q=" . $task->getEventQueueId(),
+          FALSE,
+          TRUE
+        );
         $mailParams['html'] .= "\n" . '<img src="' .
-          $config->userFrameworkResourceURL . "extern/open.php?q=" . $task->getEventQueueId() .
+          $tracking_url .
           "\" width='1' height='1' alt='' border='0'>";
 
         $task->setMailParams($mailParams);


### PR DESCRIPTION
Originating from [dev/core#17](https://lab.civicrm.org/dev/mail/issues/17), there are circumstances which cause tracking links in mailings be corrupted due to CiviCRM adding language prefixes into `\CRM_Core_Config::singleton()->userFrameworkResourceURL`. This happens when creating a mailing in a different language than the current UI language and causes the open e-mail tracking link within the image tag not be valid and thus nothing being tracked.

The underlying problem is somewhere in CiviCRM core code which constructs and caches this setting variable. In the meantime, this PR provides a workaround by doing the following:

- Do not use `\CRM_Core_Config::singleton()->userFrameworkResourceURL` since it may be broken
- Construct the URL using the relative representation of `userFrameworkResourceURL` with `\Civi::settings()->get()`
- Run the resulting URL through `\CRM_Core_Config::singleton()->userSystem->languageNegotiationURL()` with the `removeLanguagePart`parameter set to `TRUE`