### PR TITLE
OpenTracker - Create URL via CRM_Utils_System::externUrl()

### DIFF
--- a/src/Listener/OpenTracker.php
+++ b/src/Listener/OpenTracker.php
@@ -26,14 +26,19 @@ class OpenTracker extends BaseListener {
 
     $config = \CRM_Core_Config::singleton();
 
+    // TODO: After v5.21 goes EOL, remove the $isLegacy check.
+    $isLegacy = !is_callable(['CRM_Utils_System', 'externUrl']);
+
     foreach ($e->getTasks() as $task) {
       /** @var \Civi\FlexMailer\FlexMailerTask $task */
       $mailParams = $task->getMailParams();
 
       if (!empty($mailParams) && !empty($mailParams['html'])) {
-        $mailParams['html'] .= "\n" . '<img src="' .
-          $config->userFrameworkResourceURL . "extern/open.php?q=" . $task->getEventQueueId() .
-          "\" width='1' height='1' alt='' border='0'>";
+        $openUrl = $isLegacy
+          ? $config->userFrameworkResourceURL . "extern/open.php?q=" . $task->getEventQueueId()
+          : \CRM_Utils_System::externUrl('extern/open', "q=" . $task->getEventQueueId());
+
+        $mailParams['html'] .= "\n" . '<img src="' . htmlentities($openUrl) . "\" width='1' height='1' alt='' border='0'>";
 
         $task->setMailParams($mailParams);
       }

--- a/src/Listener/OpenTracker.php
+++ b/src/Listener/OpenTracker.php
@@ -27,7 +27,7 @@ class OpenTracker extends BaseListener {
     $config = \CRM_Core_Config::singleton();
 
     // TODO: After v5.21 goes EOL, remove the $isLegacy check.
-    $isLegacy = !is_callable(['CRM_Utils_System', 'externUrl']);
+    $isLegacy = version_compare(\CRM_Utils_System::version(), '5.23.alpha', '<');
 
     foreach ($e->getTasks() as $task) {
       /** @var \Civi\FlexMailer\FlexMailerTask $task */


### PR DESCRIPTION
This aims to improve cooperation between `flexmailer`, `civicrm-wordpress:wp-rest/`, and https://github.com/civicrm/civicrm-core/pull/17312 -- so that flexmailer produces compliant URLs.

Before
------

The open-tracking URL is constructed as a reference to the standalone script `extern/open.php` using certain `$config` properties.

It always links to the standalone script, even if you have a different end-point available (e.g. `civicrm/mailing/open` or `civicrm-wordpress:wp-rest/`).

After
-----

On Civi v5.23+, it uses `CRM_Utils_System::externUrl()` API to request the full URL of `extern/open`.  Flexmailer is no longer responsible for figuring the URL, and other agents (via `hook_civicrm_alterExternUrl`) can do so.

On Civi v5.22 and earlier, it continues using the same old formula. This provides drop-in/bug-level-compatibility on older versions. This can be removed in a couple months.

Comments
--------

I suspect this also fixes [dev/mail#17](https://lab.civicrm.org/dev/mail/issues/17), wherein the open tracker has flawed URLs in certain multilingual configurations. However, I can't confirm for certain because I don't have that configuration.

But just to game this out...

* If the current patch fixes dev/mail#17, then huzza!
* If it doesn't, then the problem is in `civicrm-core`'s `CRM_Utils_System::externUrl()`
  (not `flexmailer:OpenTracker.php`). Which means:
    * The problem already affects other use-cases in `civirm-core` in v5.23+.
    * The fix should go in `civicrm-core`.

Either way, addressing dev/mail#17 shouldn't require any further change in `flexmailer`.