### PR TITLE
Fixes #61: partial revert the old autoloader to avoid cache problems

### DIFF
--- a/flexmailer.php
+++ b/flexmailer.php
@@ -15,6 +15,37 @@ require_once 'flexmailer.civix.php';
 use CRM_Flexmailer_ExtensionUtil as E;
 
 /**
+ * Define an autoloader for FlexMailer.
+ *
+ * FlexMailer uses the namespace 'Civi\FlexMailer', but the
+ * autoloader in Civi v4.6 doesn't support this, so we provide
+ * our own autoloader.
+ *
+ * TODO: This was scheduled for removal in 2018 but causes sites to crash unless
+ * we "rm files/civicrm/templates/templates_c/CachedCiviContainer*" manually.
+ * Now that the autoloader is in info.xml, if sites upgrade to a newer flexmailer
+ * version, eventually we can remove this without having cache problems.
+ * See: https://github.com/civicrm/org.civicrm.flexmailer/issues/61
+ *
+ * @link http://www.php-fig.org/psr/psr-4/examples/
+ */
+function _flexmailer_autoload($class) {
+  $prefix = 'Civi\\FlexMailer\\';
+  $base_dir = __DIR__ . '/src/';
+  $len = strlen($prefix);
+  if (strncmp($prefix, $class, $len) !== 0) {
+    return;
+  }
+  $relative_class = substr($class, $len);
+  $file = $base_dir . str_replace('\\', '/', $relative_class) . '.php';
+  if (file_exists($file)) {
+    require $file;
+  }
+}
+
+spl_autoload_register('_flexmailer_autoload');
+
+/**
  * Implements hook_civicrm_config().
  *
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_config


### PR DESCRIPTION
See #61 

Upgrading flexmailer on an existing site causes cache problems. Deleting the cache manually fixes the issue, but only if we delete the cache files manually (with "rm"), because CiviCRM won't boot.

To reproduce:

* Go to an existing CiviCRM site
* Update the flexmailer extension.
* Accessing CivICRM will fatal, as per #61

Until we find a better fix, this PR reverts the removal of the legacy autoload code.

Once the cache is flushed (with the new version of flexmailer), the old autoload is not necessary anymore.