### PR TITLE
issue#59: Default flexmailer_traditional to flexmailer

### DIFF
--- a/src/Listener/Abdicator.php
+++ b/src/Listener/Abdicator.php
@@ -40,15 +40,10 @@ class Abdicator {
     }
 
     switch (\Civi::settings()->get('flexmailer_traditional')) {
-      case 'auto':
-        // Transitional support for old hidden setting "experimentalFlexMailerEngine" (bool)
-        // TODO: Remove this. Maybe after Q4 2019.
-        // TODO: Change this to default to flexmailer
-        return (bool) \Civi::settings()->get('experimentalFlexMailerEngine');
-
       case 'bao':
         return FALSE;
 
+      case 'auto':
       case 'flexmailer':
         return TRUE;
 


### PR DESCRIPTION
Follow-up to #59: this removes the `experimentalFlexMailerEngine` setting and defaults the "auto" mode to flexmailer.

People can still revert to the old BAO using the Flexmailer setting in Admin > CiviMail > Flexmailer Settings (or set the `flexmailer_traditional` setting to `traditional`).

I have not done much testing yet. I plan to deploy/enable it on production sites, and wanted to open the PR for discussion.